### PR TITLE
Fix InternLM supervision label alignment

### DIFF
--- a/internvl/model/internvl_chat/configuration_internvl_chat.py
+++ b/internvl/model/internvl_chat/configuration_internvl_chat.py
@@ -53,25 +53,37 @@ class InternVLChatConfig(PretrainedConfig):
             )
 
         if llm_config is None:
-            # TODO: There might still be a bug in transformers version 4.44 and above.
-            llm_config = {"architectures": [""]}
+            llm_config = InternLM2Config().to_dict()
+            llm_config["architectures"] = ["InternLM2ForCausalLM"]
             logger.info(
-                "llm_config is None. Initializing the LlamaConfig config with default values (`LlamaConfig`)."
+                "llm_config is None. Initializing the InternLM2Config with default values."
             )
 
+        architectures = llm_config.get("architectures") or [""]
+        if not architectures[0]:
+            architecture_by_model_type = {
+                "llama": "LlamaForCausalLM",
+                "internlm2": "InternLM2ForCausalLM",
+                "phi3": "Phi3ForCausalLM",
+                "qwen2": "Qwen2ForCausalLM",
+            }
+            inferred_architecture = architecture_by_model_type.get(
+                llm_config.get("model_type"), "InternLM2ForCausalLM"
+            )
+            llm_config = {**llm_config, "architectures": [inferred_architecture]}
+            architectures = llm_config["architectures"]
+
         self.vision_config = InternVisionConfig(**vision_config)
-        if llm_config["architectures"][0] == "LlamaForCausalLM":
+        if architectures[0] == "LlamaForCausalLM":
             self.llm_config = LlamaConfig(**llm_config)
-        elif llm_config["architectures"][0] == "InternLM2ForCausalLM":
+        elif architectures[0] == "InternLM2ForCausalLM":
             self.llm_config = InternLM2Config(**llm_config)
-        elif llm_config["architectures"][0] == "Phi3ForCausalLM":
+        elif architectures[0] == "Phi3ForCausalLM":
             self.llm_config = Phi3Config(**llm_config)
-        elif llm_config["architectures"][0] == "Qwen2ForCausalLM":
+        elif architectures[0] == "Qwen2ForCausalLM":
             self.llm_config = Qwen2Config(**llm_config)
         else:
-            raise ValueError(
-                "Unsupported architecture: {}".format(llm_config["architectures"][0])
-            )
+            raise ValueError("Unsupported architecture: {}".format(architectures[0]))
         self.use_backbone_lora = use_backbone_lora
         self.use_llm_lora = use_llm_lora
         self.pad2square = pad2square

--- a/internvl/model/internvl_chat/modeling_internvl_chat.py
+++ b/internvl/model/internvl_chat/modeling_internvl_chat.py
@@ -48,6 +48,7 @@ class InternVLChatModel(PreTrainedModel):
     config_class = InternVLChatConfig
     main_input_name = "pixel_values"
     base_model_prefix = "language_model"
+    all_tied_weights_keys = {}
     _no_split_modules = [
         "InternVisionModel",
         "LlamaDecoderLayer",
@@ -641,7 +642,8 @@ class InternVLChatModel(PreTrainedModel):
         return x
 
     def extract_feature(self, pixel_values):
-        pixel_values = pixel_values.to(torch.bfloat16)
+        vision_dtype = self.vision_model.embeddings.patch_embedding.weight.dtype
+        pixel_values = pixel_values.to(vision_dtype)
         if self.select_layer == -1:
             vit_embeds = self.vision_model(
                 pixel_values=pixel_values, output_hidden_states=False, return_dict=True

--- a/internvl/model/internvl_chat/modeling_internvl_chat.py
+++ b/internvl/model/internvl_chat/modeling_internvl_chat.py
@@ -926,8 +926,12 @@ class InternVLChatModel(PreTrainedModel):
         # Calculate MSE scores
         for idx in range(available_autoencoders):
             autoencoder = self.autoencoders[idx].to(seq_reps.device)
-            reconstructions = autoencoder(seq_reps).bfloat16()
-            per_element_loss = mse_loss(reconstructions, seq_reps)
+            autoencoder_dtype = next(autoencoder.parameters()).dtype
+            seq_reps_for_autoencoder = seq_reps.to(dtype=autoencoder_dtype)
+            reconstructions = autoencoder(seq_reps_for_autoencoder)
+            per_element_loss = mse_loss(
+                reconstructions.float(), seq_reps_for_autoencoder.float()
+            )
             per_sample_mse = per_element_loss.mean(dim=1)
             mse_scores[:, idx] = per_sample_mse.detach().cpu().float().numpy()
 

--- a/internvl/patch/__init__.py
+++ b/internvl/patch/__init__.py
@@ -4,18 +4,75 @@
 # Licensed under The MIT License [see LICENSE for details]
 # --------------------------------------------------------
 
-from .internlm2_packed_training_patch import replace_internlm2_attention_class
+def _optional_accelerator_stub(symbol_name, dependency_name):
+    def _missing_dependency(*args, **kwargs):
+        raise ImportError(
+            f"{symbol_name} requires optional dependency {dependency_name!r}, "
+            f"but it is not installed in the current environment."
+        )
+
+    return _missing_dependency
+
+
+try:
+    from .internlm2_packed_training_patch import replace_internlm2_attention_class
+except ModuleNotFoundError as exc:
+    if exc.name != 'flash_attn':
+        raise
+    replace_internlm2_attention_class = _optional_accelerator_stub(
+        'replace_internlm2_attention_class', 'flash_attn'
+    )
+
 from .internvit_liger_monkey_patch import apply_liger_kernel_to_internvit
-from .llama2_flash_attn_monkey_patch import replace_llama2_attn_with_flash_attn
-from .llama_flash_attn_monkey_patch import replace_llama_attn_with_flash_attn
-from .llama_packed_training_patch import replace_llama_attention_class
+
+try:
+    from .llama2_flash_attn_monkey_patch import replace_llama2_attn_with_flash_attn
+except ModuleNotFoundError as exc:
+    if exc.name != 'flash_attn':
+        raise
+    replace_llama2_attn_with_flash_attn = _optional_accelerator_stub(
+        'replace_llama2_attn_with_flash_attn', 'flash_attn'
+    )
+
+try:
+    from .llama_flash_attn_monkey_patch import replace_llama_attn_with_flash_attn
+except ModuleNotFoundError as exc:
+    if exc.name != 'flash_attn':
+        raise
+    replace_llama_attn_with_flash_attn = _optional_accelerator_stub(
+        'replace_llama_attn_with_flash_attn', 'flash_attn'
+    )
+
+try:
+    from .llama_packed_training_patch import replace_llama_attention_class
+except ModuleNotFoundError as exc:
+    if exc.name != 'flash_attn':
+        raise
+    replace_llama_attention_class = _optional_accelerator_stub(
+        'replace_llama_attention_class', 'flash_attn'
+    )
 from .llama_rmsnorm_monkey_patch import \
     replace_llama_rmsnorm_with_fused_rmsnorm
 from .pad_data_collator import (concat_pad_data_collator,
                                 dpo_concat_pad_data_collator,
                                 pad_data_collator)
-from .phi3_packed_training_patch import replace_phi3_attention_class
-from .qwen2_packed_training_patch import replace_qwen2_attention_class
+try:
+    from .phi3_packed_training_patch import replace_phi3_attention_class
+except ModuleNotFoundError as exc:
+    if exc.name != 'flash_attn':
+        raise
+    replace_phi3_attention_class = _optional_accelerator_stub(
+        'replace_phi3_attention_class', 'flash_attn'
+    )
+
+try:
+    from .qwen2_packed_training_patch import replace_qwen2_attention_class
+except ModuleNotFoundError as exc:
+    if exc.name != 'flash_attn':
+        raise
+    replace_qwen2_attention_class = _optional_accelerator_stub(
+        'replace_qwen2_attention_class', 'flash_attn'
+    )
 from .train_dataloader_patch import replace_train_dataloader
 from .train_sampler_patch import replace_train_sampler
 

--- a/internvl/patch/train_dataloader_patch.py
+++ b/internvl/patch/train_dataloader_patch.py
@@ -11,6 +11,19 @@ from torch.utils.data import DataLoader
 from transformers.trainer import is_datasets_available, seed_worker
 
 
+def _compat_seed_worker(worker_id: int):
+    try:
+        return seed_worker(worker_id)
+    except TypeError:
+        worker_info = torch.utils.data.get_worker_info()
+        num_workers = worker_info.num_workers if worker_info is not None else 1
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            rank = torch.distributed.get_rank()
+        else:
+            rank = 0
+        return seed_worker(worker_id, num_workers, rank)
+
+
 def get_train_dataloader(self) -> DataLoader:
     """
     Returns the training [`~torch.utils.data.DataLoader`].
@@ -41,7 +54,7 @@ def get_train_dataloader(self) -> DataLoader:
     if not isinstance(train_dataset, torch.utils.data.IterableDataset):
         dataloader_params['sampler'] = self._get_train_sampler()
         dataloader_params['drop_last'] = self.args.dataloader_drop_last
-        dataloader_params['worker_init_fn'] = seed_worker
+        dataloader_params['worker_init_fn'] = _compat_seed_worker
 
     if self.args.use_packed_ds:
         return DataLoader(train_dataset, **dataloader_params)

--- a/internvl/patch/train_sampler_patch.py
+++ b/internvl/patch/train_sampler_patch.py
@@ -103,11 +103,18 @@ def _get_train_sampler(self) -> Optional[torch.utils.data.Sampler]:
     if self.train_dataset is None or not has_length(self.train_dataset):
         return None
     # Build the sampler.
-    if self.args.group_by_length:
+    if getattr(self.args, 'group_by_length', False):
         lengths = []
         for dataset in self.train_dataset.datasets:
             lengths = lengths + dataset.length
-        model_input_name = self.tokenizer.model_input_names[0] if self.tokenizer is not None else None
+        processing_class = getattr(self, 'tokenizer', None) or getattr(
+            self, 'processing_class', None
+        )
+        model_input_name = (
+            processing_class.model_input_names[0]
+            if processing_class is not None
+            else None
+        )
         return LengthGroupedSampler(
             self.args.train_batch_size,
             world_size=self.args.world_size * self.args.gradient_accumulation_steps,

--- a/internvl/scorer/compute_seq_rep.py
+++ b/internvl/scorer/compute_seq_rep.py
@@ -76,6 +76,34 @@ warnings.filterwarnings("ignore")
 logger = logging.getLogger(__name__)
 
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
+MODEL_DTYPE_ENV = "DMOLE_MODEL_DTYPE"
+
+
+def resolve_model_dtype() -> torch.dtype:
+    raw_dtype = os.environ.get(MODEL_DTYPE_ENV, "bfloat16").strip().lower()
+    mapping = {
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+        "float16": torch.float16,
+    }
+    if raw_dtype not in mapping:
+        raise ValueError(
+            f"Unsupported {MODEL_DTYPE_ENV}={raw_dtype!r}; "
+            "expected one of: bfloat16, float32, float16."
+        )
+    return mapping[raw_dtype]
+
+
+def cast_floating_tensors(value, dtype: torch.dtype):
+    if isinstance(value, torch.Tensor):
+        return value.to(dtype=dtype) if value.is_floating_point() else value
+    if isinstance(value, dict):
+        return {key: cast_floating_tensors(item, dtype) for key, item in value.items()}
+    if isinstance(value, list):
+        return [cast_floating_tensors(item, dtype) for item in value]
+    if isinstance(value, tuple):
+        return tuple(cast_floating_tensors(item, dtype) for item in value)
+    return value
 
 
 def len2weight(x, loss_reduction):
@@ -145,6 +173,8 @@ def main():
 
     # Set seed before initializing model.
     set_seed(training_args.seed)
+    model_dtype = resolve_model_dtype()
+    logger.info(f"Using model dtype: {model_dtype}")
 
     # Load pretrained model, tokenizer, and image processor
     tokenizer_path = model_args.model_name_or_path or model_args.llm_path
@@ -207,14 +237,14 @@ def main():
         config.min_dynamic_patch = data_args.min_dynamic_patch
         config.max_dynamic_patch = data_args.max_dynamic_patch
         model = InternVLChatModel.from_pretrained(
-            model_args.model_name_or_path, torch_dtype=torch.bfloat16, config=config
+            model_args.model_name_or_path, torch_dtype=model_dtype, config=config
         )
     else:
         logger.info("Loading ViT-6B...")
         vision_config = InternVisionConfig.from_pretrained(model_args.vision_path)
         vision_config.drop_path_rate = model_args.drop_path_rate
         vision_model = InternVisionModel.from_pretrained(
-            model_args.vision_path, torch_dtype=torch.bfloat16, config=vision_config
+            model_args.vision_path, torch_dtype=model_dtype, config=vision_config
         )
         logger.info("Loading LLaMA...")
         llm_config = AutoConfig.from_pretrained(
@@ -230,7 +260,7 @@ def main():
             logger.info("Using flash_attention_2 for LLaMA")
         llm = model_type.from_pretrained(
             model_args.llm_path,
-            torch_dtype=torch.bfloat16,
+            torch_dtype=model_dtype,
             config=llm_config,
             trust_remote_code=True,
         )
@@ -303,11 +333,13 @@ def main():
     if model_args.grad_checkpoint:
         model.language_model._set_gradient_checkpointing()
 
+    group_by_length = getattr(training_args, "group_by_length", False)
+
     train_dataset = build_datasets(
         data_args,
         tokenizer,
         model,
-        group_by_length=training_args.group_by_length,
+        group_by_length=group_by_length,
         dynamic_image_size=data_args.dynamic_image_size,
         use_thumbnail=data_args.use_thumbnail,
         min_dynamic_patch=data_args.min_dynamic_patch,
@@ -391,6 +423,7 @@ def main():
         inputs = trainer._prepare_inputs(inputs)
 
         new_inputs = process_inputs(inputs, model, tokenizer)
+        new_inputs = cast_floating_tensors(new_inputs, model_dtype)
 
         embeds = model.extract_sequence_feature(**new_inputs).detach().cpu()
 
@@ -407,6 +440,13 @@ def main():
 
     merged_embeds = [x for sublist in merged_embeds for x in sublist]
     merged_embeds = torch.cat(merged_embeds, dim=0)
+    if not torch.isfinite(merged_embeds).all():
+        nan_count = int(torch.isnan(merged_embeds).sum().item())
+        inf_count = int(torch.isinf(merged_embeds).sum().item())
+        raise RuntimeError(
+            "sequence representation contains non-finite values: "
+            f"nan_count={nan_count}, inf_count={inf_count}"
+        )
 
     logger.info("Finished computing sequence representation.")
 

--- a/internvl/scorer/compute_zc_score.py
+++ b/internvl/scorer/compute_zc_score.py
@@ -4,13 +4,15 @@
 # Licensed under The MIT License [see LICENSE for details]
 # --------------------------------------------------------
 
+import importlib.util
+import json
 import logging
 import math
 import os
 import sys
 import warnings
-from collections import defaultdict
 from functools import partial
+from pathlib import Path
 
 import torch
 import torch.distributed as dist
@@ -66,6 +68,10 @@ from internvl.train.constants import (
 from internvl.train.dataset import build_datasets
 from internvl.train.dataset_packed import packed_collate_fn
 from internvl.train.trainer import CustomTrainer
+from internvl.scorer.score_policy import (
+    FALLBACK_SCORE_PROVENANCE,
+    STRICT_SCORE_PROVENANCE,
+)
 
 # Set constants for image processing and logging
 IGNORE_INDEX = -100
@@ -80,6 +86,57 @@ logger = logging.getLogger(__name__)
 
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
 MODEL_DTYPE_ENV = "DMOLE_MODEL_DTYPE"
+REQUIRE_LONESTAR_PHYSICS_ENV = "DMOLE_REQUIRE_LONESTAR_PHYSICS"
+FAIL_ON_SANITIZED_SCORE_ENV = "DMOLE_FAIL_ON_SANITIZED_SCORE"
+GEODESIC_TRUST_SCALE = 1.0
+SCORE_EPSILON = 1e-12
+
+LONESTAR_PHYSICS_EXTENSION_ENV = "LONESTAR_PHYSICS_EXTENSION"
+
+
+def load_lonestar_physics():
+    try:
+        import lonestar_physics as installed_lonestar_physics
+
+        return installed_lonestar_physics, "python-import"
+    except Exception:
+        pass
+
+    repo_root = Path(__file__).resolve().parents[2]
+    workspace_root = repo_root.parent
+    candidate_paths: list[Path] = []
+    explicit_path = os.environ.get(LONESTAR_PHYSICS_EXTENSION_ENV, "").strip()
+    if explicit_path:
+        candidate_paths.append(Path(explicit_path))
+    candidate_paths.extend(
+        [
+            workspace_root / "lonestar-physics" / "target" / "maturin" / "liblonestar_physics.so",
+            workspace_root / "lonestar-physics" / "target" / "release" / "liblonestar_physics.so",
+            workspace_root / "lonestar-physics" / "target" / "debug" / "liblonestar_physics.so",
+        ]
+    )
+
+    for candidate_path in candidate_paths:
+        if not candidate_path.is_file():
+            continue
+        try:
+            spec = importlib.util.spec_from_file_location(
+                "lonestar_physics", candidate_path
+            )
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["lonestar_physics"] = module
+            spec.loader.exec_module(module)
+            return module, str(candidate_path)
+        except Exception:
+            sys.modules.pop("lonestar_physics", None)
+            continue
+
+    return None, None
+
+
+_lp, _lp_source = load_lonestar_physics()
 
 
 def resolve_model_dtype() -> torch.dtype:
@@ -119,6 +176,209 @@ def len2weight(x, loss_reduction):
     if loss_reduction == "square":
         return 1 / (x**0.5)
     raise NotImplementedError(loss_reduction)
+
+
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def require_lonestar_physics() -> None:
+    if env_flag(REQUIRE_LONESTAR_PHYSICS_ENV) and _lp is None:
+        raise RuntimeError(
+            "LoneStarPhysics invariance scoring is required but lonestar_physics "
+            "could not be imported or loaded from an authoritative extension artifact."
+        )
+
+
+def score_world_size() -> int:
+    if dist.is_available() and dist.is_initialized():
+        return max(dist.get_world_size(), 1)
+    return max(torch.cuda.device_count(), 1)
+
+
+def layer_modality(layer_name: str) -> str:
+    if "language_model" in layer_name:
+        return "language_model"
+    if "vision_model" in layer_name:
+        return "vision_model"
+    return "other"
+
+
+def normalize_distribution(values: list[float]) -> list[float] | None:
+    total = math.fsum(values)
+    if not math.isfinite(total) or total <= 0.0:
+        return None
+    return [max(value, 0.0) / total for value in values]
+
+
+def collect_batch_layer_scores(model, target_modules: list[str]) -> tuple[dict[str, float], set[str]]:
+    batch_scores: dict[str, float] = {}
+    sanitized_layers: set[str] = set()
+
+    for name, module in model.named_modules():
+        if not any(name.endswith(target) for target in target_modules):
+            continue
+        total_norm = 0.0
+        for param in module.parameters():
+            if param.grad is None:
+                continue
+            grad = param.grad.detach()
+            if not torch.isfinite(grad).all():
+                grad = torch.nan_to_num(grad, nan=0.0, posinf=0.0, neginf=0.0)
+                sanitized_layers.add(name)
+            total_norm += grad.norm().item()
+        batch_scores[name] = total_norm * score_world_size()
+    return batch_scores, sanitized_layers
+
+
+def summarize_modality_distributions(
+    modality_distributions: list[list[float]],
+) -> tuple[float, float]:
+    if not modality_distributions:
+        return 0.0, 0.0
+    if _lp is None:
+        return 0.0, 1.0
+
+    if len(modality_distributions) == 1:
+        return 0.0, 1.0
+
+    center = _lp.fisher_rao.frechet_mean(modality_distributions, 32)
+    variance = _lp.fisher_rao.frechet_variance(modality_distributions, center)
+    variance = 0.0 if variance is None else float(variance)
+    trust = float(
+        _lp.fisher_rao.distance_to_trust(
+            math.sqrt(max(variance, 0.0)),
+            GEODESIC_TRUST_SCALE,
+        )
+    )
+    return variance, trust
+
+
+def build_score_frame(
+    batch_layer_scores: list[dict[str, float]],
+    sanitized_layers: set[str],
+) -> tuple[DataFrame, dict[str, object]]:
+    if not batch_layer_scores:
+        raise RuntimeError("zero-cost proxy scoring produced no batches")
+
+    layer_names = sorted(
+        {
+            layer_name
+            for batch_scores in batch_layer_scores
+            for layer_name in batch_scores
+            if layer_modality(layer_name) != "other"
+        }
+    )
+    if not layer_names:
+        raise RuntimeError("zero-cost proxy scoring produced no eligible layer scores")
+
+    per_layer_history = {layer_name: [] for layer_name in layer_names}
+    modality_layers = {
+        "language_model": sorted(
+            [layer_name for layer_name in layer_names if layer_modality(layer_name) == "language_model"]
+        ),
+        "vision_model": sorted(
+            [layer_name for layer_name in layer_names if layer_modality(layer_name) == "vision_model"]
+        ),
+    }
+    modality_distributions = {"language_model": [], "vision_model": []}
+
+    for batch_scores in batch_layer_scores:
+        for layer_name in layer_names:
+            per_layer_history[layer_name].append(float(batch_scores.get(layer_name, 0.0)))
+
+        for modality_name, modality_layer_names in modality_layers.items():
+            if not modality_layer_names:
+                continue
+            raw_values = [
+                float(batch_scores.get(layer_name, 0.0))
+                for layer_name in modality_layer_names
+            ]
+            normalized = normalize_distribution(raw_values)
+            if normalized is not None:
+                modality_distributions[modality_name].append(normalized)
+
+    modality_summary: dict[str, dict[str, float]] = {}
+    for modality_name, distributions in modality_distributions.items():
+        variance, trust = summarize_modality_distributions(distributions)
+        modality_summary[modality_name] = {
+            "frechet_variance": float(variance),
+            "trust": float(trust),
+            "distribution_count": float(len(distributions)),
+        }
+
+    score_provenance = (
+        STRICT_SCORE_PROVENANCE if _lp is not None else FALLBACK_SCORE_PROVENANCE
+    )
+    records = []
+    for layer_name in layer_names:
+        modality_name = layer_modality(layer_name)
+        history = per_layer_history[layer_name]
+        raw_score = float(math.fsum(history))
+        share_history = []
+        modality_layer_names = modality_layers.get(modality_name, [])
+        for batch_scores in batch_layer_scores:
+            raw_values = [
+                float(batch_scores.get(name, 0.0))
+                for name in modality_layer_names
+            ]
+            normalized = normalize_distribution(raw_values)
+            if normalized is None:
+                share_history.append(0.0)
+                continue
+            share_history.append(
+                normalized[modality_layer_names.index(layer_name)]
+                if layer_name in modality_layer_names
+                else 0.0
+            )
+
+        share_mean = float(math.fsum(share_history) / len(share_history))
+        share_variance = float(
+            math.fsum((value - share_mean) ** 2 for value in share_history)
+            / len(share_history)
+        )
+        stability_penalty = share_variance / max(share_mean * share_mean, SCORE_EPSILON)
+        modality_trust = modality_summary.get(modality_name, {}).get("trust", 0.0)
+        modality_frechet_variance = modality_summary.get(modality_name, {}).get(
+            "frechet_variance", 0.0
+        )
+        authoritative_score = raw_score * modality_trust / (1.0 + stability_penalty)
+        if not math.isfinite(authoritative_score):
+            raise RuntimeError(
+                f"authoritative score became non-finite for layer {layer_name}"
+            )
+
+        records.append(
+            {
+                "layer": layer_name,
+                "score": authoritative_score,
+                "raw_score": raw_score,
+                "share_mean": share_mean,
+                "share_variance": share_variance,
+                "stability_penalty": stability_penalty,
+                "modality": modality_name,
+                "modality_trust": modality_trust,
+                "modality_frechet_variance": modality_frechet_variance,
+                "sanitized_nonfinite": layer_name in sanitized_layers,
+                "score_batches": len(history),
+                "score_provenance": score_provenance,
+            }
+        )
+
+    frame = DataFrame(records).sort_values(
+        by=["score", "raw_score", "layer"],
+        ascending=[False, False, True],
+        kind="mergesort",
+    )
+    manifest = {
+        "score_provenance": score_provenance,
+        "batch_count": len(batch_layer_scores),
+        "sanitized_layers": sorted(sanitized_layers),
+        "modality_summary": modality_summary,
+        "lonestar_physics_available": _lp is not None,
+        "lonestar_physics_source": _lp_source,
+    }
+    return frame, manifest
 
 
 def main():
@@ -418,6 +678,11 @@ def main():
 
     portion = model_args.zc_proxy_score_portion
     max_batch_num = int(len(train_dataloader) * portion + 0.5)
+    if max_batch_num <= 0:
+        raise RuntimeError(
+            "zc_proxy_score_portion is too small for the available dataloader; "
+            "no scoring batches would execute."
+        )
 
     logger.info(
         f"Zero-cost proxy score portion: {portion}, max_batch_num: {max_batch_num}"
@@ -425,55 +690,71 @@ def main():
 
     model = trainer._wrap_model(model).to(trainer.args.device)
 
+    require_lonestar_physics()
+    target_modules = ["attention.wqkv", "attention.wo", "attn.qkv", "attn.proj"]
     model.train()
     model.zero_grad()
+    supervised_token_total = 0
+    batch_layer_scores: list[dict[str, float]] = []
+    sanitized_layers: set[str] = set()
     for i, inputs in tqdm(enumerate(train_dataloader), total=max_batch_num):
         if i > max_batch_num:
             break
 
+        model.zero_grad(set_to_none=True)
         inputs = trainer._prepare_inputs(inputs)
         inputs = cast_floating_tensors(inputs, model_dtype)
+        supervised_tokens = int((inputs["labels"] != IGNORE_INDEX).sum().item())
+        if supervised_tokens <= 0:
+            raise RuntimeError(
+                "zero-cost proxy batch contains no supervised assistant tokens; "
+                "label masking collapsed and the score would be meaningless."
+            )
+        supervised_token_total += supervised_tokens
         loss = trainer.compute_loss(model, inputs)
 
         loss.backward()
+        if torch.distributed.get_rank() == 0:
+            current_batch_scores, current_sanitized = collect_batch_layer_scores(
+                model, target_modules
+            )
+            if current_batch_scores:
+                batch_layer_scores.append(current_batch_scores)
+            sanitized_layers.update(current_sanitized)
 
     logger.info("Finished computing zero-shot proxy score.")
+    logger.info(f"Total supervised tokens used for proxy scoring: {supervised_token_total}")
 
     logger.info("Computing zero-shot proxy score for each layer...")
 
-    target_modules = ["attention.wqkv", "attention.wo", "attn.qkv", "attn.proj"]
-
     if torch.distributed.get_rank() == 0:
-        zc_proxy_score = defaultdict(float)
-
-        for name, module in model.named_modules():
-            if any([name.endswith(target) for target in target_modules]):
-                for param in module.parameters():
-                    if param.grad is not None:
-                        zc_proxy_score[name] += param.grad.norm().item()
-                zc_proxy_score[name] *= torch.cuda.device_count()
-
-        non_finite_layers = [
-            name for name, score in zc_proxy_score.items() if not math.isfinite(score)
-        ]
-        if non_finite_layers:
-            raise RuntimeError(
-                "zero-cost proxy score contains non-finite values for layers: "
-                + ", ".join(non_finite_layers[:10])
+        if sanitized_layers:
+            if env_flag(FAIL_ON_SANITIZED_SCORE_ENV):
+                raise RuntimeError(
+                    "zero-cost proxy scoring encountered non-finite gradients in "
+                    "strict mode for layers: "
+                    + ", ".join(sorted(sanitized_layers)[:10])
+                )
+            logger.warning(
+                "Sanitized non-finite gradients before proxy scoring for %d layers.",
+                len(sanitized_layers),
             )
 
-        # sorting by score
-        zc_proxy_score = sorted(
-            zc_proxy_score.items(), key=lambda x: x[1], reverse=True
+        df, manifest = build_score_frame(batch_layer_scores, sanitized_layers)
+        total_proxy_score = float(df["score"].sum())
+        if total_proxy_score <= 0:
+            logger.warning(
+                "authoritative score surface collapsed to zero; downstream strict "
+                "selection will fail closed unless explicitly downgraded"
+            )
+
+        output_path = Path(model_args.zc_proxy_score_save_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(output_path, index=False)
+        output_path.with_suffix(".manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
         )
-
-        # save to csv
-        os.makedirs(os.path.dirname(model_args.zc_proxy_score_save_path), exist_ok=True)
-
-        # note that zc_proxy_score is already a list, so we can directly use it
-        df = DataFrame(zc_proxy_score, columns=["layer", "score"])
-
-        df.to_csv(model_args.zc_proxy_score_save_path, index=False)
 
         logger.info("Finished computing zero-shot proxy score for each layer.")
 

--- a/internvl/scorer/compute_zc_score.py
+++ b/internvl/scorer/compute_zc_score.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------
 
 import logging
+import math
 import os
 import sys
 import warnings
@@ -78,6 +79,34 @@ warnings.filterwarnings("ignore")
 logger = logging.getLogger(__name__)
 
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
+MODEL_DTYPE_ENV = "DMOLE_MODEL_DTYPE"
+
+
+def resolve_model_dtype() -> torch.dtype:
+    raw_dtype = os.environ.get(MODEL_DTYPE_ENV, "bfloat16").strip().lower()
+    mapping = {
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+        "float16": torch.float16,
+    }
+    if raw_dtype not in mapping:
+        raise ValueError(
+            f"Unsupported {MODEL_DTYPE_ENV}={raw_dtype!r}; "
+            "expected one of: bfloat16, float32, float16."
+        )
+    return mapping[raw_dtype]
+
+
+def cast_floating_tensors(value, dtype: torch.dtype):
+    if isinstance(value, torch.Tensor):
+        return value.to(dtype=dtype) if value.is_floating_point() else value
+    if isinstance(value, dict):
+        return {key: cast_floating_tensors(item, dtype) for key, item in value.items()}
+    if isinstance(value, list):
+        return [cast_floating_tensors(item, dtype) for item in value]
+    if isinstance(value, tuple):
+        return tuple(cast_floating_tensors(item, dtype) for item in value)
+    return value
 
 
 def len2weight(x, loss_reduction):
@@ -147,6 +176,8 @@ def main():
 
     # Set seed before initializing model.
     set_seed(training_args.seed)
+    model_dtype = resolve_model_dtype()
+    logger.info(f"Using model dtype: {model_dtype}")
 
     # Load pretrained model, tokenizer, and image processor
     tokenizer_path = model_args.model_name_or_path or model_args.llm_path
@@ -209,14 +240,14 @@ def main():
         config.min_dynamic_patch = data_args.min_dynamic_patch
         config.max_dynamic_patch = data_args.max_dynamic_patch
         model = InternVLChatModel.from_pretrained(
-            model_args.model_name_or_path, torch_dtype=torch.bfloat16, config=config
+            model_args.model_name_or_path, torch_dtype=model_dtype, config=config
         )
     else:
         logger.info("Loading ViT-6B...")
         vision_config = InternVisionConfig.from_pretrained(model_args.vision_path)
         vision_config.drop_path_rate = model_args.drop_path_rate
         vision_model = InternVisionModel.from_pretrained(
-            model_args.vision_path, torch_dtype=torch.bfloat16, config=vision_config
+            model_args.vision_path, torch_dtype=model_dtype, config=vision_config
         )
         logger.info("Loading LLaMA...")
         llm_config = AutoConfig.from_pretrained(
@@ -232,7 +263,7 @@ def main():
             logger.info("Using flash_attention_2 for LLaMA")
         llm = model_type.from_pretrained(
             model_args.llm_path,
-            torch_dtype=torch.bfloat16,
+            torch_dtype=model_dtype,
             config=llm_config,
             trust_remote_code=True,
         )
@@ -305,11 +336,13 @@ def main():
     if model_args.grad_checkpoint:
         model.language_model._set_gradient_checkpointing()
 
+    group_by_length = getattr(training_args, "group_by_length", False)
+
     train_dataset = build_datasets(
         data_args,
         tokenizer,
         model,
-        group_by_length=training_args.group_by_length,
+        group_by_length=group_by_length,
         dynamic_image_size=data_args.dynamic_image_size,
         use_thumbnail=data_args.use_thumbnail,
         min_dynamic_patch=data_args.min_dynamic_patch,
@@ -399,6 +432,7 @@ def main():
             break
 
         inputs = trainer._prepare_inputs(inputs)
+        inputs = cast_floating_tensors(inputs, model_dtype)
         loss = trainer.compute_loss(model, inputs)
 
         loss.backward()
@@ -418,6 +452,15 @@ def main():
                     if param.grad is not None:
                         zc_proxy_score[name] += param.grad.norm().item()
                 zc_proxy_score[name] *= torch.cuda.device_count()
+
+        non_finite_layers = [
+            name for name, score in zc_proxy_score.items() if not math.isfinite(score)
+        ]
+        if non_finite_layers:
+            raise RuntimeError(
+                "zero-cost proxy score contains non-finite values for layers: "
+                + ", ".join(non_finite_layers[:10])
+            )
 
         # sorting by score
         zc_proxy_score = sorted(

--- a/internvl/scorer/score_policy.py
+++ b/internvl/scorer/score_policy.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pandas as pd
+
+STRICT_SCORE_PROVENANCE = "LONESTAR_PHYSICS_INVARIANCE_WEIGHTED"
+FALLBACK_SCORE_PROVENANCE = "GRADIENT_NORM_NON_AUTHORITATIVE"
+REQUIRED_AUTHORITATIVE_COLUMNS = frozenset(
+    {
+        "layer",
+        "score",
+        "raw_score",
+        "share_mean",
+        "share_variance",
+        "stability_penalty",
+        "modality",
+        "modality_trust",
+        "modality_frechet_variance",
+        "sanitized_nonfinite",
+        "score_batches",
+        "score_provenance",
+    }
+)
+
+
+def _coerce_bool_series(series: pd.Series) -> pd.Series:
+    if series.dtype == bool:
+        return series
+
+    lowered = series.astype(str).str.strip().str.lower()
+    mapping = {
+        "true": True,
+        "false": False,
+        "1": True,
+        "0": False,
+        "yes": True,
+        "no": False,
+    }
+    coerced = lowered.map(mapping)
+    if coerced.isna().any():
+        raise ValueError(
+            "sanitized_nonfinite contains values that cannot be coerced to bool"
+        )
+    return coerced.astype(bool)
+
+
+def _eligible_scores(scores: pd.DataFrame) -> pd.DataFrame:
+    eligible = scores[
+        scores["layer"].astype(str).str.contains("language_model|vision_model")
+    ].copy()
+    if eligible.empty:
+        raise ValueError(
+            "score surface does not contain any language_model or vision_model rows"
+        )
+    return eligible
+
+
+def load_score_frame(
+    path: Path | str,
+    *,
+    require_authoritative: bool,
+) -> pd.DataFrame:
+    score_path = Path(path)
+    scores = pd.read_csv(score_path)
+    missing_core = {"layer", "score"} - set(scores.columns)
+    if missing_core:
+        raise ValueError(
+            f"score CSV is missing required columns {sorted(missing_core)}: {score_path}"
+        )
+
+    score_values = pd.to_numeric(scores["score"], errors="coerce")
+    if score_values.isna().any() or not score_values.map(math.isfinite).all():
+        raise ValueError(f"score CSV contains non-finite score values: {score_path}")
+    if (score_values < 0.0).any():
+        raise ValueError(f"score CSV contains negative score values: {score_path}")
+    scores = scores.assign(score=score_values.astype(float))
+
+    if not require_authoritative:
+        return _eligible_scores(scores)
+
+    missing = REQUIRED_AUTHORITATIVE_COLUMNS - set(scores.columns)
+    if missing:
+        raise ValueError(
+            "authoritative score CSV is missing required columns "
+            f"{sorted(missing)}: {score_path}"
+        )
+
+    raw_score = pd.to_numeric(scores["raw_score"], errors="coerce")
+    share_mean = pd.to_numeric(scores["share_mean"], errors="coerce")
+    share_variance = pd.to_numeric(scores["share_variance"], errors="coerce")
+    stability_penalty = pd.to_numeric(scores["stability_penalty"], errors="coerce")
+    modality_trust = pd.to_numeric(scores["modality_trust"], errors="coerce")
+    modality_frechet_variance = pd.to_numeric(
+        scores["modality_frechet_variance"], errors="coerce"
+    )
+    score_batches = pd.to_numeric(scores["score_batches"], errors="coerce")
+    sanitized = _coerce_bool_series(scores["sanitized_nonfinite"])
+    provenance = scores["score_provenance"].astype(str)
+
+    numeric_columns = {
+        "raw_score": raw_score,
+        "share_mean": share_mean,
+        "share_variance": share_variance,
+        "stability_penalty": stability_penalty,
+        "modality_trust": modality_trust,
+        "modality_frechet_variance": modality_frechet_variance,
+        "score_batches": score_batches,
+    }
+    for column_name, column_values in numeric_columns.items():
+        if column_values.isna().any() or not column_values.map(math.isfinite).all():
+            raise ValueError(
+                f"authoritative score CSV has non-finite {column_name} values: {score_path}"
+            )
+
+    if (raw_score < 0.0).any():
+        raise ValueError(f"authoritative score CSV has negative raw_score values: {score_path}")
+    if (share_mean < 0.0).any():
+        raise ValueError(f"authoritative score CSV has negative share_mean values: {score_path}")
+    if (share_variance < 0.0).any():
+        raise ValueError(
+            f"authoritative score CSV has negative share_variance values: {score_path}"
+        )
+    if (stability_penalty < 0.0).any():
+        raise ValueError(
+            f"authoritative score CSV has negative stability_penalty values: {score_path}"
+        )
+    if ((modality_trust <= 0.0) | (modality_trust > 1.0)).any():
+        raise ValueError(
+            f"authoritative score CSV has modality_trust outside (0, 1]: {score_path}"
+        )
+    if (score_batches < 1).any():
+        raise ValueError(
+            f"authoritative score CSV has score_batches < 1: {score_path}"
+        )
+    if sanitized.any():
+        raise ValueError(
+            "authoritative score CSV contains sanitized_nonfinite layers; "
+            f"rerun compute_zc_score in strict mode: {score_path}"
+        )
+    if not provenance.eq(STRICT_SCORE_PROVENANCE).all():
+        raise ValueError(
+            "authoritative score CSV does not carry strict LoneStarPhysics provenance: "
+            f"{score_path}"
+        )
+
+    scores = scores.assign(
+        raw_score=raw_score.astype(float),
+        share_mean=share_mean.astype(float),
+        share_variance=share_variance.astype(float),
+        stability_penalty=stability_penalty.astype(float),
+        modality_trust=modality_trust.astype(float),
+        modality_frechet_variance=modality_frechet_variance.astype(float),
+        score_batches=score_batches.astype(int),
+        sanitized_nonfinite=sanitized,
+    )
+    return _eligible_scores(scores)
+
+
+def _select_group_layers(scores: pd.DataFrame, count: int) -> list[str]:
+    if count <= 0 or scores.empty:
+        return []
+    ordered = scores.sort_values(
+        by=["score", "layer"],
+        ascending=[False, True],
+        kind="mergesort",
+    )
+    return ordered.head(count)["layer"].tolist()
+
+
+def select_enable_layers(
+    scores: pd.DataFrame,
+    *,
+    budget_portion: float,
+    require_authoritative: bool,
+) -> list[str]:
+    if not 0.0 < budget_portion <= 1.0:
+        raise ValueError(f"budget_portion must be in (0, 1], got {budget_portion!r}")
+
+    eligible = _eligible_scores(scores)
+    llm_scores = (
+        eligible[eligible["layer"].astype(str).str.contains("language_model")]
+        .sort_values(by=["score", "layer"], ascending=[False, True], kind="mergesort")
+        .reset_index(drop=True)
+    )
+    vit_scores = (
+        eligible[eligible["layer"].astype(str).str.contains("vision_model")]
+        .sort_values(by=["score", "layer"], ascending=[False, True], kind="mergesort")
+        .reset_index(drop=True)
+    )
+
+    total_score = float(llm_scores["score"].sum() + vit_scores["score"].sum())
+    total_budget = int(len(eligible) * budget_portion + 0.5)
+    if total_budget <= 0:
+        return []
+
+    if total_score == 0.0:
+        if require_authoritative:
+            raise ValueError(
+                "authoritative score surface collapsed to zero; rerun compute_zc_score"
+            )
+        if llm_scores.empty or vit_scores.empty:
+            raise ValueError(
+                "zero-score fallback requires both language_model and vision_model rows"
+            )
+        vit_budget = min(max(int(total_budget * 0.25), 1), len(vit_scores), total_budget)
+        llm_budget = min(total_budget - vit_budget, len(llm_scores))
+        remaining_budget = total_budget - (vit_budget + llm_budget)
+        if remaining_budget > 0:
+            extra_vit = min(remaining_budget, len(vit_scores) - vit_budget)
+            vit_budget += extra_vit
+            remaining_budget -= extra_vit
+        if remaining_budget > 0:
+            extra_llm = min(remaining_budget, len(llm_scores) - llm_budget)
+            llm_budget += extra_llm
+            remaining_budget -= extra_llm
+        if remaining_budget != 0:
+            raise ValueError("unable to satisfy zero-score fallback budget")
+
+        enable_layers = []
+        enable_layers.extend(_select_group_layers(llm_scores, llm_budget))
+        enable_layers.extend(_select_group_layers(vit_scores, vit_budget))
+    else:
+        llm_budget_portion = float(llm_scores["score"].sum()) / total_score
+        vit_budget_portion = float(vit_scores["score"].sum()) / total_score
+        vit_budget = max(
+            int(total_budget * 0.25),
+            int(total_budget * vit_budget_portion + 0.5),
+        )
+        vit_budget = min(vit_budget, len(vit_scores), total_budget)
+        llm_budget = min(total_budget - vit_budget, len(llm_scores))
+        remaining_budget = total_budget - (vit_budget + llm_budget)
+        if remaining_budget > 0:
+            if llm_budget_portion >= vit_budget_portion:
+                extra_llm = min(remaining_budget, len(llm_scores) - llm_budget)
+                llm_budget += extra_llm
+                remaining_budget -= extra_llm
+            if remaining_budget > 0:
+                extra_vit = min(remaining_budget, len(vit_scores) - vit_budget)
+                vit_budget += extra_vit
+                remaining_budget -= extra_vit
+        if remaining_budget != 0:
+            raise ValueError(
+                "unable to allocate the full D-MoLE layer budget across modalities"
+            )
+
+        enable_layers = []
+        enable_layers.extend(_select_group_layers(llm_scores, llm_budget))
+        enable_layers.extend(_select_group_layers(vit_scores, vit_budget))
+
+    if len(enable_layers) != total_budget:
+        raise AssertionError(
+            f"expected {total_budget} enabled layers, got {len(enable_layers)}"
+        )
+
+    if enable_layers and "base_model" in enable_layers[0]:
+        return [".".join(layer.split(".")[2:]) for layer in enable_layers]
+    return [".".join(layer.split(".")[0:]) for layer in enable_layers]

--- a/internvl/train/dataset.py
+++ b/internvl/train/dataset.py
@@ -1239,76 +1239,123 @@ def preprocess_internlm(
         num_image: int = 1
 ) -> Dict:
     conv = get_conv_template(template_name)
-    roles = {'human': conv.roles[0], 'gpt': conv.roles[1]}
+    add_bos_token = getattr(tokenizer, 'add_bos_token', False)
+    assistant_prefix_ids = tokenizer(
+        conv.roles[1], return_tensors='np'
+    ).input_ids[0]
+    assistant_prefix_len = (
+        assistant_prefix_ids.shape[0] - 1 if add_bos_token else assistant_prefix_ids.shape[0]
+    )
 
-    # Apply prompt templates
-    conversations = []
+    batch_input_ids = []
+    batch_targets = []
+
     for i, source in enumerate(sources):
-        if roles[source[0]['from']] != conv.roles[0]:
-            # Skip the first one if it is not from human
-            source = source[1:]
+        working_source = deepcopy(source)
+        system_prompt = conv.system_message
+        if working_source and working_source[0]['from'] == 'system':
+            system_prompt = working_source[0]['value'].strip()
+            working_source = working_source[1:]
+        elif working_source and working_source[0]['from'] != 'human':
+            working_source = working_source[1:]
 
-        conv.messages = []
-        for j, sentence in enumerate(source):
-            role = roles[sentence['from']]
-            assert role == conv.roles[j % 2], f'{i}'
-            sentence['value'] = sentence['value'].strip()
-            conv.append_message(role, sentence['value'])
-        conversations.append(conv.get_prompt())
+        batches = []
+        roles = []
+        if system_prompt is not None:
+            batches.append(
+                f"{conv.system_template.format(system_message=system_prompt)}{conv.sep}\n"
+            )
+            roles.append('system')
 
-    if not text_only:
-        new_conversations = []
-        for conversation in conversations:
-            for i in range(num_image):
-                image_tokens = f'{IMG_START_TOKEN}{IMG_CONTEXT_TOKEN * num_image_token_list[i]}{IMG_END_TOKEN}'
-                conversation = conversation.replace('<image>', image_tokens, 1)
-            new_conversations.append(conversation)
-        conversations = new_conversations
+        current_image_idx = 0
+        for j, sentence in enumerate(working_source):
+            role = sentence['from']
+            value = sentence['value'].strip()
+            expected_role = 'human' if j % 2 == 0 else 'gpt'
+            assert role == expected_role, f'{i}'
 
-    # Tokenize conversations
-    input_ids = tokenizer(
-        conversations,
-        return_tensors='pt',
-        padding=False if group_by_length or use_packed_ds else 'max_length',
-        max_length=tokenizer.model_max_length,
-        truncation=True,
-    ).input_ids
-    targets = input_ids.clone()
+            if not text_only and role == 'human':
+                image_cnt = value.count('<image>')
+                for _ in range(image_cnt):
+                    if current_image_idx == num_image:
+                        break
+                    image_tokens = (
+                        f'{IMG_START_TOKEN}'
+                        f'{IMG_CONTEXT_TOKEN * num_image_token_list[current_image_idx]}'
+                        f'{IMG_END_TOKEN}'
+                    )
+                    value = value.replace('<image>', image_tokens, 1)
+                    current_image_idx += 1
 
-    for conversation, target in zip(conversations, targets):
-        total_len = int(target.ne(tokenizer.pad_token_id).sum())  # 浦语里面 pad_token_id = eos_token_id
-        cur_len = 1
-        target[:cur_len] = IGNORE_TOKEN_ID  # <s>
-        parts = conversation.split(conv.roles[1])  # [UNUSED_TOKEN_146]assistant\n
-        info = parts[0] + conv.roles[1]
-        temp_len = len(tokenizer(info).input_ids) - 1  # 去除tokenizer的<s>
-        target[cur_len: cur_len + temp_len] = IGNORE_TOKEN_ID
-        cur_len = cur_len + temp_len
+            if role == 'human':
+                batches.append(f'{conv.roles[0]}{value}{conv.sep}\n')
+                roles.append('human')
+            elif role == 'gpt':
+                batches.append(f'{conv.roles[1]}{value}{conv.sep}\n')
+                roles.append('gpt')
+            else:
+                raise NotImplementedError(role)
 
-        for index in range(1, len(parts) - 1):
-            info = parts[index]
-            part1, part2 = info.split(conv.roles[0])
-            temp_len = len(tokenizer(part1).input_ids) - 1
-            cur_len = cur_len + temp_len
-            part = conv.roles[0] + part2 + conv.roles[1]
-            temp_len = len(tokenizer(part).input_ids) - 1
-            target[cur_len: cur_len + temp_len] = IGNORE_TOKEN_ID
-            cur_len = cur_len + temp_len
-        last_info = parts[-1]
-        temp_len = len(tokenizer(last_info).input_ids) - 1
-        cur_len = cur_len + temp_len
+        if not text_only:
+            assert current_image_idx == num_image, f'{current_image_idx} != {num_image}'
 
-        target[cur_len:] = IGNORE_TOKEN_ID
-        if False:  # Inspect and check the correctness of masking
-            z = target.clone()
-            z = torch.where(z == IGNORE_TOKEN_ID, tokenizer.unk_token_id, z)
-            print(repr(tokenizer.decode(z)))
+        if add_bos_token and batches:
+            batches[0] = tokenizer.bos_token + batches[0]
 
-        if cur_len < tokenizer.model_max_length:
-            if cur_len != total_len:
-                target[:] = IGNORE_TOKEN_ID
-                print(f'WARNING: tokenization mismatch: {cur_len} vs. {total_len}. This dataset is {ds_name}.')
-                sys.stdout.flush()
+        tokenized_batches = tokenizer(
+            batches,
+            return_tensors='np',
+            padding=False,
+            max_length=tokenizer.model_max_length,
+            truncation=False,
+        ).input_ids
+
+        if add_bos_token:
+            tokenized_batches = [item[1:] for item in tokenized_batches]
+
+        final_input_ids = []
+        final_targets = []
+        for role, input_id in zip(roles, tokenized_batches):
+            final_input_ids.append(input_id)
+            if role in {'system', 'human'}:
+                final_targets.append(np.full(input_id.shape, IGNORE_TOKEN_ID))
+            elif role == 'gpt':
+                target = input_id.copy()
+                target[:assistant_prefix_len] = IGNORE_TOKEN_ID
+                target[-1:] = IGNORE_TOKEN_ID
+                final_targets.append(target)
+            else:
+                raise NotImplementedError(role)
+
+        input_tensor = torch.tensor(np.concatenate(final_input_ids))[:tokenizer.model_max_length]
+        target_tensor = torch.tensor(np.concatenate(final_targets))[:tokenizer.model_max_length]
+        batch_input_ids.append(input_tensor)
+        batch_targets.append(target_tensor)
+
+    pad_sequence = torch.nn.utils.rnn.pad_sequence
+    input_ids = pad_sequence(
+        batch_input_ids,
+        batch_first=True,
+        padding_value=tokenizer.pad_token_id,
+    )
+    targets = pad_sequence(
+        batch_targets,
+        batch_first=True,
+        padding_value=IGNORE_TOKEN_ID,
+    )
+
+    if not group_by_length and not use_packed_ds:
+        if input_ids.size(1) < tokenizer.model_max_length:
+            input_ids = F.pad(
+                input_ids,
+                (0, tokenizer.model_max_length - input_ids.size(1)),
+                value=tokenizer.pad_token_id,
+            )
+            targets = F.pad(
+                targets,
+                (0, tokenizer.model_max_length - targets.size(1)),
+                value=IGNORE_TOKEN_ID,
+            )
 
     return dict(
         input_ids=input_ids,

--- a/internvl/train/internvl_chat_finetune.py
+++ b/internvl/train/internvl_chat_finetune.py
@@ -66,6 +66,29 @@ logger = logging.getLogger(__name__)
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
 
 
+def _resolve_dmole_precision_policy():
+    dtype_name = os.environ.get("DMOLE_FORCE_TORCH_DTYPE", "bfloat16").strip().lower()
+    attn_impl = os.environ.get(
+        "DMOLE_FORCE_ATTN_IMPLEMENTATION", "flash_attention_2"
+    ).strip()
+
+    dtype_map = {
+        "float32": torch.float32,
+        "fp32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+    }
+    if dtype_name not in dtype_map:
+        raise ValueError(
+            f"Unsupported DMOLE_FORCE_TORCH_DTYPE={dtype_name!r}; expected one of "
+            "'float32', 'fp32', 'bfloat16', or 'bf16'."
+        )
+    if not attn_impl:
+        raise ValueError("DMOLE_FORCE_ATTN_IMPLEMENTATION must not be empty.")
+
+    return dtype_name, dtype_map[dtype_name], attn_impl
+
+
 def len2weight(x, loss_reduction):
     if x == 0:
         return x
@@ -199,14 +222,15 @@ def main():
         # apply_liger_kernel_to_internvit()
 
     logger.info("Loading InternVLChatModel...")
+    dtype_name, model_torch_dtype, attn_implementation = _resolve_dmole_precision_policy()
     config = InternVLChatConfig.from_pretrained(model_args.model_name_or_path)
     config.vision_config.drop_path_rate = model_args.drop_path_rate
     if config.llm_config.model_type == "internlm2":
-        config.llm_config.attn_implementation = "flash_attention_2"  # for InternLM
-        logger.info("Using flash_attention_2 for InternLM")
+        config.llm_config.attn_implementation = attn_implementation  # for InternLM
+        logger.info("Using %s attention for InternLM", attn_implementation)
     else:
-        config.llm_config._attn_implementation = "flash_attention_2"  # for LLaMA
-        logger.info("Using flash_attention_2 for LLaMA")
+        config.llm_config._attn_implementation = attn_implementation  # for LLaMA
+        logger.info("Using %s attention for LLaMA", attn_implementation)
     config.template = data_args.conv_style
     config.select_layer = model_args.vision_select_layer
     config.dynamic_image_size = data_args.dynamic_image_size
@@ -219,8 +243,9 @@ def main():
     config.autoencoder_path = model_args.autoencoder_path
     config.task_id = model_args.task_id
     model = InternVLChatModel.from_pretrained(
-        model_args.model_name_or_path, torch_dtype=torch.bfloat16, config=config
+        model_args.model_name_or_path, torch_dtype=model_torch_dtype, config=config
     )
+    logger.info("Using model torch dtype: %s", dtype_name)
     model.img_context_token_id = img_context_token_id
 
     assert model.config.downsample_ratio == data_args.down_sample_ratio

--- a/internvl/train/internvl_chat_finetune.py
+++ b/internvl/train/internvl_chat_finetune.py
@@ -133,10 +133,11 @@ def main():
 
     # Detecting last checkpoint and eventually continue from last checkpoint.
     last_checkpoint = None
+    overwrite_output_dir = getattr(training_args, "overwrite_output_dir", False)
     if (
         os.path.isdir(training_args.output_dir)
         and training_args.do_train
-        and not training_args.overwrite_output_dir
+        and not overwrite_output_dir
     ):
         last_checkpoint = get_last_checkpoint(training_args.output_dir)
         if last_checkpoint is None and len(os.listdir(training_args.output_dir)) > 0:

--- a/internvl/train/internvl_chat_finetune.py
+++ b/internvl/train/internvl_chat_finetune.py
@@ -272,11 +272,13 @@ def main():
     if model_args.grad_checkpoint:
         model.language_model._set_gradient_checkpointing()
 
+    group_by_length = getattr(training_args, "group_by_length", False)
+
     train_dataset = build_datasets(
         data_args,
         tokenizer,
         model,
-        group_by_length=training_args.group_by_length,
+        group_by_length=group_by_length,
         dynamic_image_size=data_args.dynamic_image_size,
         use_thumbnail=data_args.use_thumbnail,
         min_dynamic_patch=data_args.min_dynamic_patch,

--- a/internvl/train/trainer.py
+++ b/internvl/train/trainer.py
@@ -80,6 +80,11 @@ def save_lora_weights(
 
 
 class CustomTrainer(Trainer):
+    def __init__(self, *args, tokenizer=None, processing_class=None, **kwargs):
+        if processing_class is None and tokenizer is not None:
+            processing_class = tokenizer
+        super().__init__(*args, processing_class=processing_class, **kwargs)
+
     def _save(self, output_dir: str, state_dict=None):
         if (
             not self.model.config.use_llm_lora

--- a/internvl/train/trainer.py
+++ b/internvl/train/trainer.py
@@ -96,22 +96,34 @@ class CustomTrainer(Trainer):
         lora_state_dict = save_lora_weights(self.model, output_dir)
 
         torch.save(self.args, os.path.join(output_dir, "training_args.bin"))
+        self.model.config.save_pretrained(output_dir)
+
+        processing_class = getattr(self, "processing_class", None) or getattr(
+            self, "tokenizer", None
+        )
+        if processing_class is not None and hasattr(processing_class, "save_pretrained"):
+            processing_class.save_pretrained(output_dir)
 
         logger.info(
             f"Model configuration, LoRA weights, tokenizer, and metadata saved to {output_dir}"
         )
 
-        super()._save(output_dir, state_dict=lora_state_dict)
-
 
 class DMoLETrainer(CustomTrainer):
 
-    def compute_loss(self, model, inputs, return_outputs=False):
+    def compute_loss(
+        self,
+        model,
+        inputs,
+        return_outputs=False,
+        num_items_in_batch=None,
+    ):
         """
         How the loss is computed by Trainer. By default, all models return the loss in the first element.
 
         Subclass and override for custom behavior.
         """
+        del num_items_in_batch
         if self.label_smoother is not None and "labels" in inputs:
             labels = inputs.pop("labels")
         else:
@@ -128,6 +140,9 @@ class DMoLETrainer(CustomTrainer):
 
         if current_task_id is not None:
             try:
+                processing_class = getattr(self, "tokenizer", None) or getattr(
+                    self, "processing_class", None
+                )
                 # Set no experts for sequence representation computation
                 if hasattr(model, "module"):
                     model.module.set_expert_masks([])
@@ -139,7 +154,11 @@ class DMoLETrainer(CustomTrainer):
                 if labels is not None:
                     inputs_copy["labels"] = labels  # restore labels for process_inputs
 
-                new_inputs = process_inputs(inputs_copy, real_model, self.tokenizer)
+                new_inputs = process_inputs(
+                    inputs_copy,
+                    real_model,
+                    processing_class,
+                )
 
                 # get sequence representations
                 if hasattr(model, "module"):
@@ -174,7 +193,7 @@ class DMoLETrainer(CustomTrainer):
 
         # Save past state if it exists
         # TODO: this needs to be fixed and made cleaner later.
-        if self.args.past_index >= 0:
+        if getattr(self.args, "past_index", -1) >= 0:
             self._past = outputs[self.args.past_index]
 
         if labels is not None:

--- a/scripts/preprocess/get_dmole_arch.py
+++ b/scripts/preprocess/get_dmole_arch.py
@@ -1,91 +1,7 @@
 import json
 import os
 
-import pandas as pd
-
-
-def get_enable_layers(scores: pd.DataFrame, budget_portion: float):
-    # Split scores into LLM and ViT scores
-    llm_scores = (
-        scores[scores["layer"].str.contains("language_model")]
-        .sort_values(by="score", ascending=False)
-        .reset_index(drop=True)
-    )
-    vit_scores = (
-        scores[scores["layer"].str.contains("vision_model")]
-        .sort_values(by="score", ascending=False)
-        .reset_index(drop=True)
-    )
-
-    # Calculate adaptive budget portions for LLM and ViT
-    total_score = llm_scores["score"].sum() + vit_scores["score"].sum()
-    llm_budget_portion = llm_scores["score"].sum() / total_score
-    vit_budget_portion = vit_scores["score"].sum() / total_score
-
-    # Calculate the number of layers to enable based on budget portion for LLM and ViT
-    total_budget = int(len(scores) * budget_portion + 0.5)
-
-    # Set minimum portion for ViT layers to at least 1/4 of the total budget
-    vit_min_budget = max(
-        int(total_budget * 0.25), int(total_budget * vit_budget_portion + 0.5)
-    )
-    llm_enable_layers_count = total_budget - vit_min_budget
-
-    # Select top layers from LLM and ViT
-    enable_layers = []
-
-    # LLM layers selection
-    if llm_enable_layers_count > 0:
-        llm_threshold = llm_scores.iloc[llm_enable_layers_count - 1]["score"]
-        llm_enable_layers = list(
-            llm_scores[llm_scores["score"] > llm_threshold]["layer"]
-        )
-
-        if len(llm_scores[llm_scores["score"] == llm_threshold]) > 1:
-            remaining_layers = llm_scores[llm_scores["score"] == llm_threshold][
-                "layer"
-            ].sample(
-                n=llm_enable_layers_count - len(llm_enable_layers), random_state=42
-            )
-            llm_enable_layers.extend(remaining_layers.tolist())
-        else:
-            llm_enable_layers = list(
-                llm_scores[llm_scores["score"] >= llm_threshold]["layer"]
-            )
-
-    # ViT layers selection
-    if vit_min_budget > 0:
-        vit_threshold = vit_scores.iloc[vit_min_budget - 1]["score"]
-        vit_enable_layers = list(
-            vit_scores[vit_scores["score"] > vit_threshold]["layer"]
-        )
-
-        if len(vit_scores[vit_scores["score"] == vit_threshold]) > 1:
-            remaining_layers = vit_scores[vit_scores["score"] == vit_threshold][
-                "layer"
-            ].sample(n=vit_min_budget - len(vit_enable_layers), random_state=42)
-            vit_enable_layers.extend(remaining_layers.tolist())
-        else:
-            vit_enable_layers = list(
-                vit_scores[vit_scores["score"] >= vit_threshold]["layer"]
-            )
-
-    # Combine LLM and ViT enabled layers
-    enable_layers.extend(llm_enable_layers)
-    enable_layers.extend(vit_enable_layers)
-
-    # Format layer names if "base_model" exists in the names
-    if enable_layers and "base_model" in enable_layers[0]:
-        enable_layers = [".".join(layer.split(".")[2:]) for layer in enable_layers]
-    else:
-        enable_layers = [".".join(layer.split(".")[0:]) for layer in enable_layers]
-
-    # Ensure that the number of enabled layers matches the expected count
-    assert (
-        len(enable_layers) == total_budget
-    ), "The number of enabled layers is not correct."
-
-    return enable_layers
+from internvl.scorer.score_policy import load_score_frame, select_enable_layers
 
 
 zc_scores_dir = "results/zc_scores"
@@ -103,28 +19,31 @@ tasks = [
 ]
 num_tasks = len(tasks)
 
-dataframes = {}
-
 cur_arch = {}
+require_authoritative = os.environ.get("DMOLE_REQUIRE_AUTHORITATIVE_SCORE", "").strip() == "1"
 
 for i in range(1, num_tasks + 1):
-    taskname = tasks[i - 1]  # Map the task names dynamically
+    taskname = tasks[i - 1]
     file_name = os.path.join(zc_scores_dir, f"{i}_InternVL2-2B_{taskname}_score.csv")
-    if os.path.exists(file_name):
-        dataframes[taskname] = pd.read_csv(file_name)
+    if not os.path.exists(file_name):
+        raise FileNotFoundError(file_name)
 
-    for layer in dataframes[taskname]["layer"]:
-        if layer not in cur_arch:
-            cur_arch[layer] = []
+    score_frame = load_score_frame(
+        file_name,
+        require_authoritative=require_authoritative,
+    )
 
-    enable_layers = get_enable_layers(dataframes[taskname], budget_portion=0.5)
+    for layer in score_frame["layer"]:
+        cur_arch.setdefault(layer, [])
+
+    enable_layers = select_enable_layers(
+        score_frame,
+        budget_portion=0.5,
+        require_authoritative=require_authoritative,
+    )
     for layer in enable_layers:
-        if layer not in cur_arch:
-            cur_arch[layer] = [i]
-        else:
-            cur_arch[layer].append(i)
+        cur_arch.setdefault(layer, []).append(i)
 
-    # save the current architecture and sort keys
     os.makedirs("dmole_arch", exist_ok=True)
     with open(f"dmole_arch/{i}_InternVL2-2B_{taskname}_arch.json", "w") as f:
         json.dump(cur_arch, f, indent=4, sort_keys=True)

--- a/scripts/preprocess/get_dmole_arch_single_task.py
+++ b/scripts/preprocess/get_dmole_arch_single_task.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Generate a single-task D-MoLE architecture JSON from one zero-cost score CSV."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import pandas as pd
+
+
+def get_enable_layers(scores: pd.DataFrame, budget_portion: float) -> list[str]:
+    llm_scores = (
+        scores[scores["layer"].str.contains("language_model")]
+        .sort_values(by="score", ascending=False)
+        .reset_index(drop=True)
+    )
+    vit_scores = (
+        scores[scores["layer"].str.contains("vision_model")]
+        .sort_values(by="score", ascending=False)
+        .reset_index(drop=True)
+    )
+
+    total_score = llm_scores["score"].sum() + vit_scores["score"].sum()
+    if not math.isfinite(total_score) or total_score <= 0:
+        raise ValueError(
+            f"non-finite or non-positive total score encountered: {total_score!r}"
+        )
+    llm_budget_portion = llm_scores["score"].sum() / total_score
+    vit_budget_portion = vit_scores["score"].sum() / total_score
+    total_budget = int(len(scores) * budget_portion + 0.5)
+
+    vit_min_budget = max(
+        int(total_budget * 0.25), int(total_budget * vit_budget_portion + 0.5)
+    )
+    llm_enable_layers_count = total_budget - vit_min_budget
+
+    enable_layers: list[str] = []
+
+    if llm_enable_layers_count > 0:
+        llm_threshold = llm_scores.iloc[llm_enable_layers_count - 1]["score"]
+        llm_enable_layers = list(
+            llm_scores[llm_scores["score"] > llm_threshold]["layer"]
+        )
+        if len(llm_scores[llm_scores["score"] == llm_threshold]) > 1:
+            remaining_layers = llm_scores[llm_scores["score"] == llm_threshold][
+                "layer"
+            ].sample(
+                n=llm_enable_layers_count - len(llm_enable_layers), random_state=42
+            )
+            llm_enable_layers.extend(remaining_layers.tolist())
+        else:
+            llm_enable_layers = list(
+                llm_scores[llm_scores["score"] >= llm_threshold]["layer"]
+            )
+        enable_layers.extend(llm_enable_layers)
+
+    if vit_min_budget > 0:
+        vit_threshold = vit_scores.iloc[vit_min_budget - 1]["score"]
+        vit_enable_layers = list(
+            vit_scores[vit_scores["score"] > vit_threshold]["layer"]
+        )
+        if len(vit_scores[vit_scores["score"] == vit_threshold]) > 1:
+            remaining_layers = vit_scores[vit_scores["score"] == vit_threshold][
+                "layer"
+            ].sample(n=vit_min_budget - len(vit_enable_layers), random_state=42)
+            vit_enable_layers.extend(remaining_layers.tolist())
+        else:
+            vit_enable_layers = list(
+                vit_scores[vit_scores["score"] >= vit_threshold]["layer"]
+            )
+        enable_layers.extend(vit_enable_layers)
+
+    assert len(enable_layers) == total_budget, "unexpected enabled-layer count"
+
+    if enable_layers and "base_model" in enable_layers[0]:
+        return [".".join(layer.split(".")[2:]) for layer in enable_layers]
+    return [".".join(layer.split(".")[0:]) for layer in enable_layers]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--task-name", required=True)
+    parser.add_argument("--task-id", type=int, required=True)
+    parser.add_argument("--score-path", type=Path, required=True)
+    parser.add_argument("--output-path", type=Path, required=True)
+    parser.add_argument("--budget-portion", type=float, default=0.5)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    scores = pd.read_csv(args.score_path)
+    score_values = scores["score"].astype(float)
+    if not score_values.map(math.isfinite).all():
+        raise ValueError(f"score CSV contains non-finite values: {args.score_path}")
+    scores = scores.assign(score=score_values)
+    enable_layers = get_enable_layers(scores, budget_portion=args.budget_portion)
+    architecture = {layer: [args.task_id] for layer in sorted(enable_layers)}
+    args.output_path.parent.mkdir(parents=True, exist_ok=True)
+    args.output_path.write_text(
+        json.dumps(architecture, indent=4, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"wrote single-task architecture to {args.output_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preprocess/get_dmole_arch_single_task.py
+++ b/scripts/preprocess/get_dmole_arch_single_task.py
@@ -5,79 +5,9 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 from pathlib import Path
 
-import pandas as pd
-
-
-def get_enable_layers(scores: pd.DataFrame, budget_portion: float) -> list[str]:
-    llm_scores = (
-        scores[scores["layer"].str.contains("language_model")]
-        .sort_values(by="score", ascending=False)
-        .reset_index(drop=True)
-    )
-    vit_scores = (
-        scores[scores["layer"].str.contains("vision_model")]
-        .sort_values(by="score", ascending=False)
-        .reset_index(drop=True)
-    )
-
-    total_score = llm_scores["score"].sum() + vit_scores["score"].sum()
-    if not math.isfinite(total_score) or total_score <= 0:
-        raise ValueError(
-            f"non-finite or non-positive total score encountered: {total_score!r}"
-        )
-    llm_budget_portion = llm_scores["score"].sum() / total_score
-    vit_budget_portion = vit_scores["score"].sum() / total_score
-    total_budget = int(len(scores) * budget_portion + 0.5)
-
-    vit_min_budget = max(
-        int(total_budget * 0.25), int(total_budget * vit_budget_portion + 0.5)
-    )
-    llm_enable_layers_count = total_budget - vit_min_budget
-
-    enable_layers: list[str] = []
-
-    if llm_enable_layers_count > 0:
-        llm_threshold = llm_scores.iloc[llm_enable_layers_count - 1]["score"]
-        llm_enable_layers = list(
-            llm_scores[llm_scores["score"] > llm_threshold]["layer"]
-        )
-        if len(llm_scores[llm_scores["score"] == llm_threshold]) > 1:
-            remaining_layers = llm_scores[llm_scores["score"] == llm_threshold][
-                "layer"
-            ].sample(
-                n=llm_enable_layers_count - len(llm_enable_layers), random_state=42
-            )
-            llm_enable_layers.extend(remaining_layers.tolist())
-        else:
-            llm_enable_layers = list(
-                llm_scores[llm_scores["score"] >= llm_threshold]["layer"]
-            )
-        enable_layers.extend(llm_enable_layers)
-
-    if vit_min_budget > 0:
-        vit_threshold = vit_scores.iloc[vit_min_budget - 1]["score"]
-        vit_enable_layers = list(
-            vit_scores[vit_scores["score"] > vit_threshold]["layer"]
-        )
-        if len(vit_scores[vit_scores["score"] == vit_threshold]) > 1:
-            remaining_layers = vit_scores[vit_scores["score"] == vit_threshold][
-                "layer"
-            ].sample(n=vit_min_budget - len(vit_enable_layers), random_state=42)
-            vit_enable_layers.extend(remaining_layers.tolist())
-        else:
-            vit_enable_layers = list(
-                vit_scores[vit_scores["score"] >= vit_threshold]["layer"]
-            )
-        enable_layers.extend(vit_enable_layers)
-
-    assert len(enable_layers) == total_budget, "unexpected enabled-layer count"
-
-    if enable_layers and "base_model" in enable_layers[0]:
-        return [".".join(layer.split(".")[2:]) for layer in enable_layers]
-    return [".".join(layer.split(".")[0:]) for layer in enable_layers]
+from internvl.scorer.score_policy import load_score_frame, select_enable_layers
 
 
 def parse_args() -> argparse.Namespace:
@@ -87,17 +17,26 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--score-path", type=Path, required=True)
     parser.add_argument("--output-path", type=Path, required=True)
     parser.add_argument("--budget-portion", type=float, default=0.5)
+    parser.add_argument(
+        "--allow-non-authoritative-score",
+        action="store_true",
+        help="Permit legacy score CSVs that are not LoneStarPhysics invariance weighted.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    scores = pd.read_csv(args.score_path)
-    score_values = scores["score"].astype(float)
-    if not score_values.map(math.isfinite).all():
-        raise ValueError(f"score CSV contains non-finite values: {args.score_path}")
-    scores = scores.assign(score=score_values)
-    enable_layers = get_enable_layers(scores, budget_portion=args.budget_portion)
+    require_authoritative = not args.allow_non_authoritative_score
+    scores = load_score_frame(
+        args.score_path,
+        require_authoritative=require_authoritative,
+    )
+    enable_layers = select_enable_layers(
+        scores,
+        budget_portion=args.budget_portion,
+        require_authoritative=require_authoritative,
+    )
     architecture = {layer: [args.task_id] for layer in sorted(enable_layers)}
     args.output_path.parent.mkdir(parents=True, exist_ok=True)
     args.output_path.write_text(

--- a/scripts/preprocess/minimal_1gpu_vizwiz_caption_pipeline.sh
+++ b/scripts/preprocess/minimal_1gpu_vizwiz_caption_pipeline.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DMOLE_ENV="${DMOLE_ENV:-/home/jpgtex/.venvs/dmole-research}"
+PYTHON_BIN="${DMOLE_ENV}/bin/python"
+
+export PATH="${DMOLE_ENV}/bin:${PATH}"
+export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+export MASTER_PORT="${MASTER_PORT:-34229}"
+export LAUNCHER="${LAUNCHER:-pytorch}"
+export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-3}"
+export TOKENIZERS_PARALLELISM="${TOKENIZERS_PARALLELISM:-true}"
+export DMOLE_MODEL_DTYPE="${DMOLE_MODEL_DTYPE:-float32}"
+BF16_FLAG="${DMOLE_BF16:-False}"
+ZC_FORCE_IMAGE_SIZE="${DMOLE_ZC_FORCE_IMAGE_SIZE:-224}"
+ZC_MAX_DYNAMIC_PATCH="${DMOLE_ZC_MAX_DYNAMIC_PATCH:-1}"
+ZC_MAX_SEQ_LENGTH="${DMOLE_ZC_MAX_SEQ_LENGTH:-512}"
+ZC_BATCH_SIZE="${DMOLE_ZC_BATCH_SIZE:-1}"
+ZC_GRAD_CHECKPOINT="${DMOLE_ZC_GRAD_CHECKPOINT:-True}"
+
+TASK_NAME="vizwiz_caption"
+TASK_ID=1
+SAMPLE_SIZE="${DMOLE_SAMPLE_SIZE:-256}"
+META_PATH="${REPO_ROOT}/shell/dmole_internal/vizwiz_caption_minimal.json"
+EMBEDDING_PATH="${REPO_ROOT}/embeddings/vizwiz_caption_minimal/embeddings.pt"
+AUTOENCODER_ROOT="${REPO_ROOT}/autoencoder_models"
+SCORE_PATH="${REPO_ROOT}/results/zc_scores/1_InternVL2-2B_vizwiz_caption_score.csv"
+ARCH_PATH="${REPO_ROOT}/dmole_arch/1_InternVL2-2B_vizwiz_caption_arch.json"
+MODEL_PATH="${REPO_ROOT}/pretrained/InternVL2-2B"
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "FATAL: required file is missing: $path" >&2
+    exit 1
+  fi
+}
+
+require_executable() {
+  local path="$1"
+  if [[ ! -x "$path" ]]; then
+    echo "FATAL: executable is missing: $path" >&2
+    exit 1
+  fi
+}
+
+require_executable "$PYTHON_BIN"
+require_file "${MODEL_PATH}/config.json"
+
+"$PYTHON_BIN" "${REPO_ROOT}/scripts/preprocess/reconstruct_public_dmole_assets.py" \
+  --task vizwiz_caption \
+  --repo-root "${REPO_ROOT}" \
+  --sample-size "${SAMPLE_SIZE}"
+
+"$PYTHON_BIN" -m torch.distributed.run \
+  --nnodes=1 \
+  --node_rank=0 \
+  --master_addr=127.0.0.1 \
+  --nproc_per_node=1 \
+  --master_port="${MASTER_PORT}" \
+  "${REPO_ROOT}/internvl/scorer/compute_seq_rep.py" \
+  --model_name_or_path "${MODEL_PATH}" \
+  --output_dir none \
+  --conv_style "internlm2-chat" \
+  --meta_path "${META_PATH}" \
+  --force_image_size 448 \
+  --max_dynamic_patch 6 \
+  --down_sample_ratio 0.5 \
+  --drop_path_rate 0.0 \
+  --freeze_llm True \
+  --freeze_mlp True \
+  --freeze_backbone True \
+  --vision_select_layer -1 \
+  --bf16 "${BF16_FLAG}" \
+  --num_train_epochs 1 \
+  --max_seq_length 2048 \
+  --per_device_train_batch_size 2
+
+require_file "${EMBEDDING_PATH}"
+
+"$PYTHON_BIN" "${REPO_ROOT}/scripts/preprocess/train_autoencoder_single_task.py" \
+  --task-name "${TASK_NAME}" \
+  --embedding-path "${EMBEDDING_PATH}" \
+  --output-dir "${AUTOENCODER_ROOT}"
+
+"$PYTHON_BIN" -m torch.distributed.run \
+  --nnodes=1 \
+  --node_rank=0 \
+  --master_addr=127.0.0.1 \
+  --nproc_per_node=1 \
+  --master_port="$((MASTER_PORT + 1))" \
+  "${REPO_ROOT}/internvl/scorer/compute_zc_score.py" \
+  --model_name_or_path "${MODEL_PATH}" \
+  --output_dir none \
+  --conv_style "internlm2-chat" \
+  --meta_path "${META_PATH}" \
+  --force_image_size "${ZC_FORCE_IMAGE_SIZE}" \
+  --max_dynamic_patch "${ZC_MAX_DYNAMIC_PATCH}" \
+  --down_sample_ratio 0.5 \
+  --drop_path_rate 0.0 \
+  --vision_select_layer -1 \
+  --bf16 "${BF16_FLAG}" \
+  --num_train_epochs 1 \
+  --max_seq_length "${ZC_MAX_SEQ_LENGTH}" \
+  --per_device_train_batch_size "${ZC_BATCH_SIZE}" \
+  --grad_checkpoint "${ZC_GRAD_CHECKPOINT}" \
+  --zc_proxy_score_portion 0.01 \
+  --zc_proxy_score_save_path "${SCORE_PATH}"
+
+require_file "${SCORE_PATH}"
+
+"$PYTHON_BIN" "${REPO_ROOT}/scripts/preprocess/get_dmole_arch_single_task.py" \
+  --task-name "${TASK_NAME}" \
+  --task-id "${TASK_ID}" \
+  --score-path "${SCORE_PATH}" \
+  --output-path "${ARCH_PATH}"
+
+require_file "${ARCH_PATH}"
+require_file "${AUTOENCODER_ROOT}/${TASK_NAME}/autoencoder.pt"
+require_file "${AUTOENCODER_ROOT}/${TASK_NAME}/threshold.txt"
+require_file "${AUTOENCODER_ROOT}/reconstruction_loss_quantiles.csv"
+
+echo "minimal VizWiz caption D-MoLE preprocessing completed successfully."

--- a/scripts/preprocess/minimal_1gpu_vizwiz_caption_pipeline.sh
+++ b/scripts/preprocess/minimal_1gpu_vizwiz_caption_pipeline.sh
@@ -13,10 +13,16 @@ export LAUNCHER="${LAUNCHER:-pytorch}"
 export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-3}"
 export TOKENIZERS_PARALLELISM="${TOKENIZERS_PARALLELISM:-true}"
 export DMOLE_MODEL_DTYPE="${DMOLE_MODEL_DTYPE:-float32}"
+export DMOLE_REQUIRE_LONESTAR_PHYSICS="${DMOLE_REQUIRE_LONESTAR_PHYSICS:-1}"
+export DMOLE_FAIL_ON_SANITIZED_SCORE="${DMOLE_FAIL_ON_SANITIZED_SCORE:-1}"
 BF16_FLAG="${DMOLE_BF16:-False}"
+SEQ_FORCE_IMAGE_SIZE="${DMOLE_SEQ_FORCE_IMAGE_SIZE:-224}"
+SEQ_MAX_DYNAMIC_PATCH="${DMOLE_SEQ_MAX_DYNAMIC_PATCH:-1}"
+SEQ_MAX_SEQ_LENGTH="${DMOLE_SEQ_MAX_SEQ_LENGTH:-1024}"
+SEQ_BATCH_SIZE="${DMOLE_SEQ_BATCH_SIZE:-1}"
 ZC_FORCE_IMAGE_SIZE="${DMOLE_ZC_FORCE_IMAGE_SIZE:-224}"
 ZC_MAX_DYNAMIC_PATCH="${DMOLE_ZC_MAX_DYNAMIC_PATCH:-1}"
-ZC_MAX_SEQ_LENGTH="${DMOLE_ZC_MAX_SEQ_LENGTH:-512}"
+ZC_MAX_SEQ_LENGTH="${DMOLE_ZC_MAX_SEQ_LENGTH:-1024}"
 ZC_BATCH_SIZE="${DMOLE_ZC_BATCH_SIZE:-1}"
 ZC_GRAD_CHECKPOINT="${DMOLE_ZC_GRAD_CHECKPOINT:-True}"
 
@@ -46,8 +52,62 @@ require_executable() {
   fi
 }
 
+require_python_module() {
+  local module_name="$1"
+  if ! "$PYTHON_BIN" - "$module_name" "${REPO_ROOT}" <<'PY'
+import importlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+def load_lonestar_physics_from_candidates(repo_root: Path) -> bool:
+    candidate_paths = []
+    explicit_path = os.environ.get("LONESTAR_PHYSICS_EXTENSION", "").strip()
+    if explicit_path:
+        candidate_paths.append(Path(explicit_path))
+    workspace_root = repo_root.parent
+    candidate_paths.extend(
+        [
+            workspace_root / "lonestar-physics" / "target" / "maturin" / "liblonestar_physics.so",
+            workspace_root / "lonestar-physics" / "target" / "release" / "liblonestar_physics.so",
+            workspace_root / "lonestar-physics" / "target" / "debug" / "liblonestar_physics.so",
+        ]
+    )
+    for candidate_path in candidate_paths:
+        if not candidate_path.is_file():
+            continue
+        spec = importlib.util.spec_from_file_location("lonestar_physics", candidate_path)
+        if spec is None or spec.loader is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["lonestar_physics"] = module
+        spec.loader.exec_module(module)
+        return True
+    return False
+
+module_name = sys.argv[1]
+repo_root = Path(sys.argv[2]).resolve()
+
+try:
+    importlib.import_module(module_name)
+except Exception:
+    if module_name != "lonestar_physics" or not load_lonestar_physics_from_candidates(
+        repo_root
+    ):
+        raise
+PY
+  then
+    echo "FATAL: required Python module is unavailable: ${module_name}" >&2
+    exit 1
+  fi
+}
+
 require_executable "$PYTHON_BIN"
 require_file "${MODEL_PATH}/config.json"
+if [[ "${DMOLE_REQUIRE_LONESTAR_PHYSICS}" == "1" ]]; then
+  require_python_module "lonestar_physics"
+fi
 
 "$PYTHON_BIN" "${REPO_ROOT}/scripts/preprocess/reconstruct_public_dmole_assets.py" \
   --task vizwiz_caption \
@@ -65,8 +125,8 @@ require_file "${MODEL_PATH}/config.json"
   --output_dir none \
   --conv_style "internlm2-chat" \
   --meta_path "${META_PATH}" \
-  --force_image_size 448 \
-  --max_dynamic_patch 6 \
+  --force_image_size "${SEQ_FORCE_IMAGE_SIZE}" \
+  --max_dynamic_patch "${SEQ_MAX_DYNAMIC_PATCH}" \
   --down_sample_ratio 0.5 \
   --drop_path_rate 0.0 \
   --freeze_llm True \
@@ -75,8 +135,8 @@ require_file "${MODEL_PATH}/config.json"
   --vision_select_layer -1 \
   --bf16 "${BF16_FLAG}" \
   --num_train_epochs 1 \
-  --max_seq_length 2048 \
-  --per_device_train_batch_size 2
+  --max_seq_length "${SEQ_MAX_SEQ_LENGTH}" \
+  --per_device_train_batch_size "${SEQ_BATCH_SIZE}"
 
 require_file "${EMBEDDING_PATH}"
 
@@ -110,6 +170,7 @@ require_file "${EMBEDDING_PATH}"
   --zc_proxy_score_save_path "${SCORE_PATH}"
 
 require_file "${SCORE_PATH}"
+require_file "${SCORE_PATH%.csv}.manifest.json"
 
 "$PYTHON_BIN" "${REPO_ROOT}/scripts/preprocess/get_dmole_arch_single_task.py" \
   --task-name "${TASK_NAME}" \

--- a/scripts/preprocess/reconstruct_public_dmole_assets.py
+++ b/scripts/preprocess/reconstruct_public_dmole_assets.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Reconstruct internal D-MoLE assets from public upstream sources.
+
+This script intentionally keeps all reconstructed outputs local to the repo.
+It currently supports the minimal VizWiz captioning lane needed to qualify the
+single-GPU D-MoLE evidence path without relying on the blocked monolithic
+Google Drive tarball.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import shutil
+import urllib.error
+import urllib.request
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Iterable
+
+
+VIZWIZ_CAPTION_ANNOTATIONS_URL = (
+    "https://vizwiz.cs.colorado.edu/VizWiz_final/caption/annotations.zip"
+)
+VIZWIZ_CAPTION_TRAIN_ZIP_URL = "https://vizwiz.cs.colorado.edu/VizWiz_final/images/train.zip"
+VIZWIZ_CAPTION_PROMPT = "Provide a one-sentence caption for the provided image."
+
+
+def display_path(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
+
+
+def download_file(url: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists() and destination.stat().st_size > 0:
+        return
+    print(f"downloading {url} -> {destination}", flush=True)
+    tmp_path = destination.with_suffix(destination.suffix + ".part")
+    with urllib.request.urlopen(url) as response, tmp_path.open("wb") as handle:
+        shutil.copyfileobj(response, handle)
+    tmp_path.replace(destination)
+
+
+def extract_zip_member(zip_path: Path, member_prefix: str, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as archive:
+        for member in archive.namelist():
+            if not member.startswith(member_prefix):
+                continue
+            target = output_dir / Path(member).name
+            if target.exists() and target.stat().st_size > 0:
+                continue
+            with archive.open(member) as source, target.open("wb") as destination:
+                shutil.copyfileobj(source, destination)
+
+
+def sanitize_caption(caption: str) -> str:
+    return " ".join(caption.strip().split())
+
+
+def download_many_image_urls(pairs: Iterable[tuple[str, Path]], workers: int) -> None:
+    errors: list[str] = []
+
+    def fetch(url: str, destination: Path) -> None:
+        try:
+            download_file(url, destination)
+        except urllib.error.URLError as exc:
+            errors.append(f"{url} -> {destination}: {exc}")
+
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as executor:
+        for url, destination in pairs:
+            executor.submit(fetch, url, destination)
+
+    if errors:
+        raise RuntimeError(
+            "failed to download one or more VizWiz caption images:\n"
+            + "\n".join(errors[:10])
+        )
+
+
+def extract_selected_images_from_zip(
+    zip_path: Path, file_names: Iterable[str], output_dir: Path
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    requested = set(file_names)
+    missing = requested.copy()
+    with zipfile.ZipFile(zip_path) as archive:
+        by_name = {Path(member).name: member for member in archive.namelist()}
+        for file_name in requested:
+            if file_name not in by_name:
+                continue
+            destination = output_dir / file_name
+            if destination.exists() and destination.stat().st_size > 0:
+                missing.discard(file_name)
+                continue
+            with archive.open(by_name[file_name]) as source, destination.open(
+                "wb"
+            ) as handle:
+                shutil.copyfileobj(source, handle)
+            missing.discard(file_name)
+    if missing:
+        raise RuntimeError(
+            "missing expected VizWiz caption images in train.zip: "
+            + ", ".join(sorted(list(missing))[:10])
+        )
+
+
+def reconstruct_vizwiz_caption(
+    repo_root: Path, sample_size: int, seed: int, download_workers: int
+) -> None:
+    cache_root = Path(
+        os.environ.get(
+            "DMOLE_PUBLIC_CACHE_ROOT",
+            str(Path.home() / ".cache" / "dmole-public-assets"),
+        )
+    )
+    download_root = cache_root / "vizwiz-caption"
+    annotations_zip = download_root / "annotations.zip"
+    train_zip = download_root / "train.zip"
+    annotations_dir = download_root / "annotations"
+    train_annotations_path = annotations_dir / "train.json"
+    data_root = repo_root / "data" / "vizwiz-caption"
+    images_root = data_root / "images" / "train"
+    manifest_path = data_root / "internal_minimal_train.jsonl"
+    receipt_path = data_root / "public_source_receipt.json"
+    meta_path = repo_root / "shell" / "dmole_internal" / "vizwiz_caption_minimal.json"
+
+    download_file(VIZWIZ_CAPTION_ANNOTATIONS_URL, annotations_zip)
+    if not train_annotations_path.exists():
+        extract_zip_member(annotations_zip, "annotations/", annotations_dir)
+
+    raw = json.loads(train_annotations_path.read_text(encoding="utf-8"))
+    images_by_id = {item["id"]: item for item in raw["images"]}
+    annotations = raw["annotations"]
+
+    if sample_size <= 0 or sample_size >= len(annotations):
+        selected_annotations = annotations
+    else:
+        rng = random.Random(seed)
+        indices = sorted(rng.sample(range(len(annotations)), sample_size))
+        selected_annotations = [annotations[index] for index in indices]
+
+    images_root.mkdir(parents=True, exist_ok=True)
+    unique_downloads: dict[str, Path] = {}
+    for annotation in selected_annotations:
+        image_info = images_by_id[annotation["image_id"]]
+        unique_downloads.setdefault(
+            image_info["vizwiz_url"], images_root / image_info["file_name"]
+        )
+
+    try:
+        download_many_image_urls(unique_downloads.items(), workers=download_workers)
+    except RuntimeError as exc:
+        print(
+            "warning: direct VizWiz image URLs failed, falling back to the official train.zip "
+            f"bundle ({exc})",
+            flush=True,
+        )
+        download_file(VIZWIZ_CAPTION_TRAIN_ZIP_URL, train_zip)
+        print(
+            f"extracting {len(unique_downloads)} selected VizWiz images from {train_zip}",
+            flush=True,
+        )
+        extract_selected_images_from_zip(
+            train_zip,
+            [path.name for path in unique_downloads.values()],
+            images_root,
+        )
+
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with manifest_path.open("w", encoding="utf-8") as handle:
+        for annotation in selected_annotations:
+            image_info = images_by_id[annotation["image_id"]]
+            record = {
+                "id": f"vizwiz_caption_{annotation['id']}",
+                "image": f"data/vizwiz-caption/images/train/{image_info['file_name']}",
+                "conversations": [
+                    {
+                        "from": "human",
+                        "value": f"<image>\n{VIZWIZ_CAPTION_PROMPT}",
+                    },
+                    {
+                        "from": "gpt",
+                        "value": sanitize_caption(annotation["caption"]),
+                    },
+                ],
+                "source": {
+                    "dataset": "vizwiz-caption",
+                    "annotation_id": annotation["id"],
+                    "image_id": annotation["image_id"],
+                    "annotation_zip_url": VIZWIZ_CAPTION_ANNOTATIONS_URL,
+                    "image_url": image_info["vizwiz_url"],
+                    "text_detected": annotation.get("text_detected"),
+                    "is_precanned": annotation.get("is_precanned"),
+                    "is_rejected": annotation.get("is_rejected"),
+                },
+            }
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_payload = {
+        "vizwiz-caption": {
+            "root": ".",
+            "annotation": "data/vizwiz-caption/internal_minimal_train.jsonl",
+            "data_augment": False,
+            "repeat_time": 1,
+            "length": len(selected_annotations),
+        }
+    }
+    meta_path.write_text(
+        json.dumps(meta_payload, indent=4, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+    receipt_payload = {
+        "task": "vizwiz_caption",
+        "mode": "public_source_internal_reconstruction",
+        "annotation_zip_url": VIZWIZ_CAPTION_ANNOTATIONS_URL,
+        "train_zip_url": VIZWIZ_CAPTION_TRAIN_ZIP_URL,
+        "cache_root": str(download_root),
+        "annotation_json": display_path(train_annotations_path, repo_root),
+        "output_manifest": display_path(manifest_path, repo_root),
+        "output_meta": display_path(meta_path, repo_root),
+        "sample_size": len(selected_annotations),
+        "seed": seed,
+        "image_count": len(unique_downloads),
+        "prompt": VIZWIZ_CAPTION_PROMPT,
+    }
+    receipt_path.write_text(
+        json.dumps(receipt_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--task",
+        choices=("vizwiz_caption",),
+        default="vizwiz_caption",
+        help="Public-source reconstruction task to execute.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repo root for D-MoLE-Research.",
+    )
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=256,
+        help="Number of public annotations to stage into the internal training manifest.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=20260409,
+        help="Deterministic seed for sampling public annotations.",
+    )
+    parser.add_argument(
+        "--download-workers",
+        type=int,
+        default=max(4, min(16, (os.cpu_count() or 4))),
+        help="Parallel worker count for image downloads.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    if args.task == "vizwiz_caption":
+        reconstruct_vizwiz_caption(
+            repo_root,
+            sample_size=args.sample_size,
+            seed=args.seed,
+            download_workers=args.download_workers,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preprocess/train_autoencoder_single_task.py
+++ b/scripts/preprocess/train_autoencoder_single_task.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Train or refresh a single-task D-MoLE autoencoder artifact."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader, TensorDataset
+
+from internvl.model.autoencoder import AutoEncoder
+
+
+QUANTILES = [0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99]
+
+
+def l2_normalize(embeddings: torch.Tensor) -> torch.Tensor:
+    norm = embeddings.norm(p=2, dim=1, keepdim=True)
+    return embeddings / norm.clamp_min(1e-12)
+
+
+def train_autoencoder(
+    model: AutoEncoder,
+    embeddings: torch.Tensor,
+    *,
+    device: torch.device,
+    num_epochs: int,
+    batch_size: int,
+    patience: int,
+) -> AutoEncoder:
+    dataset = TensorDataset(embeddings)
+    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    criterion = nn.MSELoss()
+    optimizer = optim.Adam(model.parameters(), lr=0.005)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=num_epochs, eta_min=1e-3
+    )
+
+    best_loss = float("inf")
+    stagnant_epochs = 0
+    model.train()
+
+    for epoch in range(num_epochs):
+        total_loss = 0.0
+        for batch, in dataloader:
+            batch = batch.to(device)
+            optimizer.zero_grad()
+            outputs = model(batch)
+            loss = criterion(outputs, batch)
+            if not torch.isfinite(loss):
+                raise RuntimeError(
+                    f"autoencoder loss became non-finite at epoch {epoch + 1}"
+                )
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item()
+
+        total_loss /= max(1, len(dataloader))
+        scheduler.step()
+        print(f"epoch {epoch + 1}/{num_epochs} loss={total_loss:.8f}", flush=True)
+
+        if total_loss < best_loss:
+            best_loss = total_loss
+            stagnant_epochs = 0
+        else:
+            stagnant_epochs += 1
+            if stagnant_epochs >= patience:
+                print(
+                    f"early stop after epoch {epoch + 1} with best_loss={best_loss:.8f}",
+                    flush=True,
+                )
+                break
+
+    return model
+
+
+def write_quantile_table(
+    *,
+    task_name: str,
+    losses: torch.Tensor,
+    csv_path: Path,
+) -> None:
+    quantile_values = torch.quantile(
+        losses, torch.tensor(QUANTILES, device=losses.device)
+    ).detach()
+    row = {
+        "min": losses.min().item(),
+        "Q10": quantile_values[0].item(),
+        "Q25": quantile_values[1].item(),
+        "Q50": quantile_values[2].item(),
+        "Q75": quantile_values[3].item(),
+        "Q90": quantile_values[4].item(),
+        "Q95": quantile_values[5].item(),
+        "Q99": quantile_values[6].item(),
+        "max": losses.max().item(),
+        "mean": losses.mean().item(),
+        "std": losses.std().item(),
+    }
+
+    if csv_path.exists():
+        df = pd.read_csv(csv_path, index_col=0)
+    else:
+        df = pd.DataFrame(
+            columns=["min", "Q10", "Q25", "Q50", "Q75", "Q90", "Q95", "Q99", "max", "mean", "std"]
+        )
+
+    df.loc[task_name] = row
+    df = df.sort_index()
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(csv_path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--task-name", required=True)
+    parser.add_argument("--embedding-path", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--hidden-dim", type=int, default=128)
+    parser.add_argument("--num-epochs", type=int, default=50)
+    parser.add_argument("--batch-size", type=int, default=512)
+    parser.add_argument("--patience", type=int, default=5)
+    parser.add_argument(
+        "--threshold-quantile",
+        type=float,
+        default=0.95,
+        help="Quantile used to materialize threshold.txt for task routing.",
+    )
+    parser.add_argument(
+        "--force-retrain",
+        action="store_true",
+        help="Retrain even if autoencoder.pt already exists.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    task_dir = args.output_dir / args.task_name
+    task_dir.mkdir(parents=True, exist_ok=True)
+
+    embeddings = torch.load(args.embedding_path, map_location=device).to(torch.float32)
+    if not torch.isfinite(embeddings).all():
+        nan_count = int(torch.isnan(embeddings).sum().item())
+        inf_count = int(torch.isinf(embeddings).sum().item())
+        raise RuntimeError(
+            "embedding tensor contains non-finite values before autoencoder training: "
+            f"nan_count={nan_count}, inf_count={inf_count}"
+        )
+    embeddings = l2_normalize(embeddings).to(device)
+    input_dim = embeddings.shape[1]
+
+    autoencoder_path = task_dir / "autoencoder.pt"
+    quantile_csv_path = args.output_dir / "reconstruction_loss_quantiles.csv"
+    threshold_path = task_dir / "threshold.txt"
+
+    model = AutoEncoder(input_dim=input_dim, hidden_dim=args.hidden_dim).to(device)
+    if autoencoder_path.exists() and not args.force_retrain:
+        print(f"loading autoencoder from {autoencoder_path}", flush=True)
+        state_dict = torch.load(autoencoder_path, map_location=device)
+        model.load_state_dict(state_dict)
+    else:
+        print(f"training autoencoder for {args.task_name}", flush=True)
+        model = train_autoencoder(
+            model,
+            embeddings,
+            device=device,
+            num_epochs=args.num_epochs,
+            batch_size=args.batch_size,
+            patience=args.patience,
+        )
+        torch.save(model.state_dict(), autoencoder_path)
+        print(f"saved autoencoder to {autoencoder_path}", flush=True)
+
+    model.eval()
+    losses = model.compute_reconstruction_loss(embeddings).detach()
+    if not torch.isfinite(losses).all():
+        nan_count = int(torch.isnan(losses).sum().item())
+        inf_count = int(torch.isinf(losses).sum().item())
+        raise RuntimeError(
+            "reconstruction losses contain non-finite values: "
+            f"nan_count={nan_count}, inf_count={inf_count}"
+        )
+    threshold = torch.quantile(
+        losses, torch.tensor(args.threshold_quantile, device=losses.device)
+    ).item()
+    threshold_path.write_text(f"{threshold:.10f}\n", encoding="utf-8")
+    write_quantile_table(
+        task_name=args.task_name,
+        losses=losses,
+        csv_path=quantile_csv_path,
+    )
+    print(f"wrote threshold to {threshold_path}", flush=True)
+    print(f"updated quantile table at {quantile_csv_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train/minimal_1gpu_dmole.sh
+++ b/scripts/train/minimal_1gpu_dmole.sh
@@ -12,6 +12,13 @@ export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-3}"
 export ENABLE_EVALUATION="${ENABLE_EVALUATION:-false}"
 export DMOLE_REQUIRE_FINITE_TRAIN_SIGNAL="${DMOLE_REQUIRE_FINITE_TRAIN_SIGNAL:-1}"
 export DMOLE_REQUIRE_FINITE_INITIAL_SIGNAL="${DMOLE_REQUIRE_FINITE_INITIAL_SIGNAL:-1}"
+export DMOLE_FORCE_TORCH_DTYPE="${DMOLE_FORCE_TORCH_DTYPE:-float32}"
+export DMOLE_FORCE_ATTN_IMPLEMENTATION="${DMOLE_FORCE_ATTN_IMPLEMENTATION:-eager}"
+export DMOLE_ENABLE_BF16="${DMOLE_ENABLE_BF16:-0}"
+BF16_FLAG="False"
+if [[ "${DMOLE_ENABLE_BF16}" == "1" ]]; then
+  BF16_FLAG="True"
+fi
 
 PYTHON_BIN="${DMOLE_ENV}/bin/python"
 OUTPUT_ROOT="${SOULFORGE_OUTPUT_DIR:?SOULFORGE_OUTPUT_DIR must be set}"
@@ -223,7 +230,9 @@ probe_initial_signal() {
     --use-llm-lora 8 \
     --use-backbone-lora 8 \
     --task-id 1 \
-    --max-seq-length 2048
+    --max-seq-length 2048 \
+    --torch-dtype "${DMOLE_FORCE_TORCH_DTYPE}" \
+    --attn-implementation "${DMOLE_FORCE_ATTN_IMPLEMENTATION}"
 }
 
 require_interpreter
@@ -261,7 +270,7 @@ probe_initial_signal
   --task_id 1 \
   --vision_select_layer -1 \
   --dataloader_num_workers 1 \
-  --bf16 True \
+  --bf16 "${BF16_FLAG}" \
   --num_train_epochs 1 \
   --per_device_train_batch_size 1 \
   --gradient_accumulation_steps 1 \

--- a/scripts/train/minimal_1gpu_dmole.sh
+++ b/scripts/train/minimal_1gpu_dmole.sh
@@ -11,6 +11,7 @@ export LAUNCHER="${LAUNCHER:-pytorch}"
 export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-3}"
 export ENABLE_EVALUATION="${ENABLE_EVALUATION:-false}"
 export DMOLE_REQUIRE_FINITE_TRAIN_SIGNAL="${DMOLE_REQUIRE_FINITE_TRAIN_SIGNAL:-1}"
+export DMOLE_REQUIRE_FINITE_INITIAL_SIGNAL="${DMOLE_REQUIRE_FINITE_INITIAL_SIGNAL:-1}"
 
 PYTHON_BIN="${DMOLE_ENV}/bin/python"
 OUTPUT_ROOT="${SOULFORGE_OUTPUT_DIR:?SOULFORGE_OUTPUT_DIR must be set}"
@@ -23,6 +24,7 @@ TASK_NAME="${DMOLE_TASK_NAME:-vizwiz_caption}"
 OUTPUT_DIR="${OUTPUT_ROOT}/${TASK_NAME}_1gpu"
 DMOLE_ARCH_PATH="${DMOLE_ARCH_PATH:-${ARCH_DIR}/1_InternVL2-2B_${TASK_NAME}_arch.json}"
 TRAIN_LOG="${OUTPUT_ROOT}/${TASK_NAME}_1gpu_training.log"
+SIGNAL_PROBE_JSON="${OUTPUT_ROOT}/${TASK_NAME}_initial_signal_probe.json"
 
 require_file() {
   local path="$1"
@@ -202,12 +204,36 @@ if nonfinite_grad_rows:
 PY
 }
 
+probe_initial_signal() {
+  if [[ "${DMOLE_REQUIRE_FINITE_INITIAL_SIGNAL}" == "0" ]]; then
+    return 0
+  fi
+
+  "$PYTHON_BIN" "${REPO_ROOT}/scripts/train/probe_initial_dmole_signal.py" \
+    --model-name-or-path "${BASE_MODEL_DIR}" \
+    --meta-path "${META_PATH}" \
+    --dmole-arch-path "${DMOLE_ARCH_PATH}" \
+    --autoencoder-path "${AUTOENCODER_DIR}" \
+    --output-json "${SIGNAL_PROBE_JSON}" \
+    --force-image-size 448 \
+    --down-sample-ratio 0.5 \
+    --conv-style "internlm2-chat" \
+    --min-dynamic-patch 1 \
+    --max-dynamic-patch 6 \
+    --use-llm-lora 8 \
+    --use-backbone-lora 8 \
+    --task-id 1 \
+    --max-seq-length 2048
+}
+
 require_interpreter
 verify_runtime
 stage_checks
 
 mkdir -p "$OUTPUT_DIR"
-export OUTPUT_DIR TASK_NAME DMOLE_ARCH_PATH BASE_MODEL_DIR META_PATH TRAIN_LOG
+export OUTPUT_DIR TASK_NAME DMOLE_ARCH_PATH BASE_MODEL_DIR META_PATH TRAIN_LOG SIGNAL_PROBE_JSON
+
+probe_initial_signal
 
 "$PYTHON_BIN" -m torch.distributed.run \
   --nnodes=1 \

--- a/scripts/train/minimal_1gpu_dmole.sh
+++ b/scripts/train/minimal_1gpu_dmole.sh
@@ -10,6 +10,7 @@ export MASTER_PORT="${MASTER_PORT:-34229}"
 export LAUNCHER="${LAUNCHER:-pytorch}"
 export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-3}"
 export ENABLE_EVALUATION="${ENABLE_EVALUATION:-false}"
+export DMOLE_REQUIRE_FINITE_TRAIN_SIGNAL="${DMOLE_REQUIRE_FINITE_TRAIN_SIGNAL:-1}"
 
 PYTHON_BIN="${DMOLE_ENV}/bin/python"
 OUTPUT_ROOT="${SOULFORGE_OUTPUT_DIR:?SOULFORGE_OUTPUT_DIR must be set}"
@@ -137,12 +138,76 @@ expert_payload = {
 PY
 }
 
+validate_training_signal() {
+  if [[ "${DMOLE_REQUIRE_FINITE_TRAIN_SIGNAL}" == "0" ]]; then
+    return 0
+  fi
+
+  "$PYTHON_BIN" - <<'PY'
+import ast
+import math
+import os
+from pathlib import Path
+
+train_log = Path(os.environ["TRAIN_LOG"])
+if not train_log.is_file():
+    raise SystemExit(f"FATAL: training log is missing: {train_log}")
+
+metric_rows = []
+for raw_line in train_log.read_text(encoding="utf-8", errors="replace").splitlines():
+    start = raw_line.find("{")
+    end = raw_line.rfind("}")
+    if start < 0 or end <= start:
+        continue
+    candidate = raw_line[start : end + 1]
+    try:
+        parsed = ast.literal_eval(candidate)
+    except (SyntaxError, ValueError):
+        continue
+    if isinstance(parsed, dict) and "loss" in parsed:
+        metric_rows.append(parsed)
+
+if not metric_rows:
+    raise SystemExit("FATAL: no per-step training metrics were captured in the training log.")
+
+finite_positive_loss = False
+nonfinite_grad_rows = []
+for row in metric_rows:
+    loss_value = row.get("loss")
+    grad_value = row.get("grad_norm")
+    try:
+        if math.isfinite(float(loss_value)) and float(loss_value) > 0.0:
+            finite_positive_loss = True
+    except (TypeError, ValueError):
+        pass
+    if grad_value is not None:
+        try:
+            grad_float = float(grad_value)
+        except (TypeError, ValueError):
+            nonfinite_grad_rows.append(row)
+        else:
+            if not math.isfinite(grad_float):
+                nonfinite_grad_rows.append(row)
+
+if not finite_positive_loss:
+    raise SystemExit(
+        "FATAL: degenerate training signal detected; no strictly positive finite loss was observed."
+    )
+
+if nonfinite_grad_rows:
+    raise SystemExit(
+        f"FATAL: non-finite grad_norm detected in {len(nonfinite_grad_rows)} logged step(s); "
+        "authoritative training evidence is invalid."
+    )
+PY
+}
+
 require_interpreter
 verify_runtime
 stage_checks
 
 mkdir -p "$OUTPUT_DIR"
-export OUTPUT_DIR TASK_NAME DMOLE_ARCH_PATH BASE_MODEL_DIR META_PATH
+export OUTPUT_DIR TASK_NAME DMOLE_ARCH_PATH BASE_MODEL_DIR META_PATH TRAIN_LOG
 
 "$PYTHON_BIN" -m torch.distributed.run \
   --nnodes=1 \
@@ -192,4 +257,5 @@ export OUTPUT_DIR TASK_NAME DMOLE_ARCH_PATH BASE_MODEL_DIR META_PATH
   --report_to "none" \
   2>&1 | tee "${TRAIN_LOG}"
 
+validate_training_signal
 write_receipts

--- a/scripts/train/minimal_1gpu_dmole.sh
+++ b/scripts/train/minimal_1gpu_dmole.sh
@@ -17,11 +17,11 @@ BASE_MODEL_DIR="${DMOLE_BASE_MODEL_DIR:-${REPO_ROOT}/pretrained/InternVL2-2B}"
 DATA_DIR="${DMOLE_DATA_DIR:-${REPO_ROOT}/data}"
 ARCH_DIR="${DMOLE_ARCH_DIR:-${REPO_ROOT}/dmole_arch}"
 AUTOENCODER_DIR="${DMOLE_AUTOENCODER_DIR:-${REPO_ROOT}/autoencoder_models}"
-META_PATH="${DMOLE_META_PATH:-${REPO_ROOT}/shell/dmole/vizwiz_caption.json}"
+META_PATH="${DMOLE_META_PATH:-${REPO_ROOT}/shell/dmole_internal/vizwiz_caption_minimal.json}"
 TASK_NAME="${DMOLE_TASK_NAME:-vizwiz_caption}"
 OUTPUT_DIR="${OUTPUT_ROOT}/${TASK_NAME}_1gpu"
 DMOLE_ARCH_PATH="${DMOLE_ARCH_PATH:-${ARCH_DIR}/1_InternVL2-2B_${TASK_NAME}_arch.json}"
-TRAIN_LOG="${OUTPUT_DIR}/training_log.txt"
+TRAIN_LOG="${OUTPUT_ROOT}/${TASK_NAME}_1gpu_training.log"
 
 require_file() {
   local path="$1"
@@ -155,7 +155,6 @@ export OUTPUT_DIR TASK_NAME DMOLE_ARCH_PATH BASE_MODEL_DIR META_PATH
   --conv_style "internlm2-chat" \
   --output_dir "${OUTPUT_DIR}" \
   --meta_path "${META_PATH}" \
-  --overwrite_output_dir True \
   --force_image_size 448 \
   --max_dynamic_patch 6 \
   --down_sample_ratio 0.5 \
@@ -175,7 +174,7 @@ export OUTPUT_DIR TASK_NAME DMOLE_ARCH_PATH BASE_MODEL_DIR META_PATH
   --num_train_epochs 1 \
   --per_device_train_batch_size 1 \
   --gradient_accumulation_steps 1 \
-  --evaluation_strategy "no" \
+  --eval_strategy "no" \
   --save_strategy "steps" \
   --save_steps 10 \
   --save_total_limit 1 \
@@ -187,7 +186,6 @@ export OUTPUT_DIR TASK_NAME DMOLE_ARCH_PATH BASE_MODEL_DIR META_PATH
   --max_seq_length 2048 \
   --do_train True \
   --grad_checkpoint True \
-  --group_by_length True \
   --dynamic_image_size True \
   --use_thumbnail True \
   --ps_version 'v2' \

--- a/scripts/train/minimal_1gpu_dmole.sh
+++ b/scripts/train/minimal_1gpu_dmole.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DMOLE_ENV="${DMOLE_ENV:-/home/jpgtex/.venvs/dmole-research}"
+export PATH="${DMOLE_ENV}/bin:${PATH}"
+export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+export MASTER_PORT="${MASTER_PORT:-34229}"
+export LAUNCHER="${LAUNCHER:-pytorch}"
+export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-3}"
+export ENABLE_EVALUATION="${ENABLE_EVALUATION:-false}"
+
+PYTHON_BIN="${DMOLE_ENV}/bin/python"
+OUTPUT_ROOT="${SOULFORGE_OUTPUT_DIR:?SOULFORGE_OUTPUT_DIR must be set}"
+BASE_MODEL_DIR="${DMOLE_BASE_MODEL_DIR:-${REPO_ROOT}/pretrained/InternVL2-2B}"
+DATA_DIR="${DMOLE_DATA_DIR:-${REPO_ROOT}/data}"
+ARCH_DIR="${DMOLE_ARCH_DIR:-${REPO_ROOT}/dmole_arch}"
+AUTOENCODER_DIR="${DMOLE_AUTOENCODER_DIR:-${REPO_ROOT}/autoencoder_models}"
+META_PATH="${DMOLE_META_PATH:-${REPO_ROOT}/shell/dmole/vizwiz_caption.json}"
+TASK_NAME="${DMOLE_TASK_NAME:-vizwiz_caption}"
+OUTPUT_DIR="${OUTPUT_ROOT}/${TASK_NAME}_1gpu"
+DMOLE_ARCH_PATH="${DMOLE_ARCH_PATH:-${ARCH_DIR}/1_InternVL2-2B_${TASK_NAME}_arch.json}"
+TRAIN_LOG="${OUTPUT_DIR}/training_log.txt"
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "FATAL: required file is missing: $path" >&2
+    exit 1
+  fi
+}
+
+require_nonempty_dir() {
+  local path="$1"
+  if [[ ! -d "$path" ]]; then
+    echo "FATAL: required directory is missing: $path" >&2
+    exit 1
+  fi
+  if ! find "$path" -mindepth 1 -maxdepth 1 | read -r _; then
+    echo "FATAL: required directory is empty: $path" >&2
+    exit 1
+  fi
+}
+
+require_findable_file() {
+  local root="$1"
+  local pattern="$2"
+  if ! find "$root" -type f -name "$pattern" | read -r _; then
+    echo "FATAL: expected to find $pattern beneath $root" >&2
+    exit 1
+  fi
+}
+
+require_interpreter() {
+  if [[ ! -x "$PYTHON_BIN" ]]; then
+    echo "FATAL: dedicated D-MoLE interpreter is missing: $PYTHON_BIN" >&2
+    exit 1
+  fi
+}
+
+verify_runtime() {
+  "$PYTHON_BIN" - <<'PY'
+import importlib.util
+
+required = (
+    "torch",
+    "transformers",
+    "peft",
+    "datasets",
+    "bitsandbytes",
+    "trl",
+    "accelerate",
+    "deepspeed",
+    "einops",
+    "einops_exts",
+    "timm",
+    "shortuuid",
+    "sentencepiece",
+    "torchvision",
+    "pydantic",
+    "imageio",
+    "decord",
+)
+missing = [name for name in required if importlib.util.find_spec(name) is None]
+if missing:
+    raise SystemExit(f"FATAL: dedicated D-MoLE environment is missing modules: {', '.join(missing)}")
+PY
+}
+
+stage_checks() {
+  require_nonempty_dir "$BASE_MODEL_DIR"
+  require_nonempty_dir "$DATA_DIR"
+  require_nonempty_dir "$ARCH_DIR"
+  require_nonempty_dir "$AUTOENCODER_DIR"
+  require_file "$META_PATH"
+  require_file "$DMOLE_ARCH_PATH"
+  require_file "${BASE_MODEL_DIR}/config.json"
+  if ! find "$DATA_DIR" -type f \( -name '*.json' -o -name '*.jsonl' \) | read -r _; then
+    echo "FATAL: missing any dataset manifest (.json/.jsonl) beneath $DATA_DIR" >&2
+    exit 1
+  fi
+  if [[ ! -f "${AUTOENCODER_DIR}/reconstruction_loss_quantiles.csv" ]]; then
+    echo "FATAL: missing reconstruction_loss_quantiles.csv in $AUTOENCODER_DIR" >&2
+    exit 1
+  fi
+  require_findable_file "$AUTOENCODER_DIR" 'autoencoder.pt'
+}
+
+write_receipts() {
+  "$PYTHON_BIN" - <<'PY'
+import json
+import os
+from pathlib import Path
+
+output_dir = Path(os.environ["OUTPUT_DIR"])
+task_name = os.environ["TASK_NAME"]
+dmole_arch_path = os.environ["DMOLE_ARCH_PATH"]
+base_model_dir = os.environ["BASE_MODEL_DIR"]
+meta_path = os.environ["META_PATH"]
+
+router_payload = {
+    "route": "dmole_minimal_1gpu",
+    "task_name": task_name,
+    "dmole_arch_path": dmole_arch_path,
+    "base_model_dir": base_model_dir,
+    "meta_path": meta_path,
+}
+expert_payload = {
+    "task_name": task_name,
+    "output_dir": str(output_dir),
+    "training_log": str(output_dir / "training_log.txt"),
+}
+
+(output_dir / "dmole_router.json").write_text(json.dumps(router_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+(output_dir / "expert_manifest.json").write_text(json.dumps(expert_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
+require_interpreter
+verify_runtime
+stage_checks
+
+mkdir -p "$OUTPUT_DIR"
+export OUTPUT_DIR TASK_NAME DMOLE_ARCH_PATH BASE_MODEL_DIR META_PATH
+
+"$PYTHON_BIN" -m torch.distributed.run \
+  --nnodes=1 \
+  --node_rank=0 \
+  --master_addr=127.0.0.1 \
+  --nproc_per_node=1 \
+  --master_port="${MASTER_PORT}" \
+  "${REPO_ROOT}/internvl/train/internvl_chat_finetune.py" \
+  --model_name_or_path "${BASE_MODEL_DIR}" \
+  --conv_style "internlm2-chat" \
+  --output_dir "${OUTPUT_DIR}" \
+  --meta_path "${META_PATH}" \
+  --overwrite_output_dir True \
+  --force_image_size 448 \
+  --max_dynamic_patch 6 \
+  --down_sample_ratio 0.5 \
+  --drop_path_rate 0.0 \
+  --freeze_llm True \
+  --freeze_mlp True \
+  --freeze_backbone True \
+  --use_llm_lora 8 \
+  --use_backbone_lora 8 \
+  --use_dmole True \
+  --dmole_arch_path "${DMOLE_ARCH_PATH}" \
+  --autoencoder_path "${AUTOENCODER_DIR}" \
+  --task_id 1 \
+  --vision_select_layer -1 \
+  --dataloader_num_workers 1 \
+  --bf16 True \
+  --num_train_epochs 1 \
+  --per_device_train_batch_size 1 \
+  --gradient_accumulation_steps 1 \
+  --evaluation_strategy "no" \
+  --save_strategy "steps" \
+  --save_steps 10 \
+  --save_total_limit 1 \
+  --learning_rate 1e-4 \
+  --weight_decay 0.01 \
+  --warmup_ratio 0.03 \
+  --lr_scheduler_type "cosine" \
+  --logging_steps 1 \
+  --max_seq_length 2048 \
+  --do_train True \
+  --grad_checkpoint True \
+  --group_by_length True \
+  --dynamic_image_size True \
+  --use_thumbnail True \
+  --ps_version 'v2' \
+  --report_to "none" \
+  2>&1 | tee "${TRAIN_LOG}"
+
+write_receipts

--- a/scripts/train/probe_initial_dmole_signal.py
+++ b/scripts/train/probe_initial_dmole_signal.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from peft import PeftModel
+from transformers import AutoTokenizer
+
+from internvl.model.internvl_chat import InternVLChatConfig, InternVLChatModel
+from internvl.patch import concat_pad_data_collator
+from internvl.train.arguments import DataTrainingArguments
+from internvl.train.constants import (
+    BOX_END_TOKEN,
+    BOX_START_TOKEN,
+    IMG_CONTEXT_TOKEN,
+    IMG_END_TOKEN,
+    IMG_START_TOKEN,
+    QUAD_END_TOKEN,
+    QUAD_START_TOKEN,
+    REF_END_TOKEN,
+    REF_START_TOKEN,
+)
+from internvl.train.dataset import build_datasets
+
+
+def _ensure_single_process_dist() -> None:
+    if not dist.is_available() or not dist.is_initialized():
+        dist.get_rank = lambda: 0
+        dist.get_world_size = lambda: 1
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a strict first-batch signal probe for the internal 1-GPU D-MoLE lane."
+    )
+    parser.add_argument("--model-name-or-path", required=True)
+    parser.add_argument("--meta-path", required=True)
+    parser.add_argument("--dmole-arch-path", required=True)
+    parser.add_argument("--autoencoder-path", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--force-image-size", type=int, default=448)
+    parser.add_argument("--down-sample-ratio", type=float, default=0.5)
+    parser.add_argument("--conv-style", default="internlm2-chat")
+    parser.add_argument("--min-dynamic-patch", type=int, default=1)
+    parser.add_argument("--max-dynamic-patch", type=int, default=6)
+    parser.add_argument("--use-llm-lora", type=int, default=8)
+    parser.add_argument("--use-backbone-lora", type=int, default=8)
+    parser.add_argument("--task-id", type=int, default=1)
+    parser.add_argument("--max-seq-length", type=int, default=2048)
+    return parser
+
+
+def _configure_tokenizer(model_path: str, max_seq_length: int):
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_path,
+        add_eos_token=False,
+        trust_remote_code=True,
+        use_fast=False,
+    )
+    tokenizer.model_max_length = max_seq_length
+    token_list = [
+        IMG_START_TOKEN,
+        IMG_END_TOKEN,
+        IMG_CONTEXT_TOKEN,
+        QUAD_START_TOKEN,
+        QUAD_END_TOKEN,
+        REF_START_TOKEN,
+        REF_END_TOKEN,
+        BOX_START_TOKEN,
+        BOX_END_TOKEN,
+    ]
+    num_new_tokens = tokenizer.add_tokens(token_list, special_tokens=True)
+    img_context_token_id = tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)
+    return tokenizer, num_new_tokens, img_context_token_id
+
+
+def _configure_model(
+    args: argparse.Namespace,
+    tokenizer,
+    num_new_tokens: int,
+    img_context_token_id: int,
+):
+    config = InternVLChatConfig.from_pretrained(args.model_name_or_path)
+    if config.llm_config.model_type == "internlm2":
+        config.llm_config.attn_implementation = "flash_attention_2"
+    else:
+        config.llm_config._attn_implementation = "flash_attention_2"
+    config.template = args.conv_style
+    config.select_layer = -1
+    config.dynamic_image_size = True
+    config.use_thumbnail = True
+    config.ps_version = "v2"
+    config.min_dynamic_patch = args.min_dynamic_patch
+    config.max_dynamic_patch = args.max_dynamic_patch
+    config.use_dmole = True
+    config.dmole_arch_path = args.dmole_arch_path
+    config.autoencoder_path = args.autoencoder_path
+    config.task_id = args.task_id
+
+    model = InternVLChatModel.from_pretrained(
+        args.model_name_or_path,
+        torch_dtype=torch.bfloat16,
+        config=config,
+    )
+    model.img_context_token_id = img_context_token_id
+
+    patch_size = model.config.vision_config.patch_size
+    model.config.force_image_size = args.force_image_size
+    model.num_image_token = int(
+        (args.force_image_size // patch_size) ** 2 * (args.down_sample_ratio**2)
+    )
+
+    if num_new_tokens > 0:
+        model.language_model.resize_token_embeddings(len(tokenizer))
+
+    with open(args.dmole_arch_path, "r", encoding="utf-8") as handle:
+        dmole_arch = json.load(handle)
+    vision_dmole_arch = {
+        key.split("vision_model.", 1)[1]: value
+        for key, value in dmole_arch.items()
+        if key.startswith("vision_model.")
+    }
+    llm_dmole_arch = {
+        key.split("language_model.", 1)[1]: value
+        for key, value in dmole_arch.items()
+        if key.startswith("language_model.")
+    }
+
+    for parameter in model.language_model.parameters():
+        parameter.requires_grad = False
+    for parameter in model.vision_model.parameters():
+        parameter.requires_grad = False
+    for parameter in model.mlp1.parameters():
+        parameter.requires_grad = False
+
+    if not isinstance(model.vision_model, PeftModel):
+        model.wrap_backbone_lora(
+            r=args.use_backbone_lora,
+            lora_alpha=2 * args.use_backbone_lora,
+            dmole_arch=vision_dmole_arch,
+        )
+    if not isinstance(model.language_model, PeftModel):
+        model.wrap_llm_lora(
+            r=args.use_llm_lora,
+            lora_alpha=2 * args.use_llm_lora,
+            dmole_arch=llm_dmole_arch,
+        )
+
+    model.language_model.set_expert_masks(args.task_id)
+    model.language_model.freeze_old_experts(args.task_id)
+    model.vision_model.set_expert_masks(args.task_id)
+    model.vision_model.freeze_old_experts(args.task_id)
+    model.train()
+    return model.cuda()
+
+
+def _build_batch(args: argparse.Namespace, tokenizer, model):
+    data_args = DataTrainingArguments(
+        max_seq_length=args.max_seq_length,
+        force_image_size=args.force_image_size,
+        down_sample_ratio=args.down_sample_ratio,
+        pad2square=False,
+        conv_style=args.conv_style,
+        meta_path=args.meta_path,
+        use_data_resampling=False,
+        dynamic_image_size=True,
+        use_thumbnail=True,
+        min_dynamic_patch=args.min_dynamic_patch,
+        max_dynamic_patch=args.max_dynamic_patch,
+        normalize_type="imagenet",
+        use_packed_ds=False,
+    )
+    dataset = build_datasets(
+        data_args,
+        tokenizer,
+        model,
+        group_by_length=False,
+        dynamic_image_size=True,
+        use_thumbnail=True,
+        min_dynamic_patch=args.min_dynamic_patch,
+        max_dynamic_patch=args.max_dynamic_patch,
+        normalize_type="imagenet",
+    )
+    batch = concat_pad_data_collator([dataset[0]])
+    for key, value in list(batch.items()):
+        if isinstance(value, torch.Tensor):
+            if key == "pixel_values":
+                batch[key] = value.to(device="cuda", dtype=torch.bfloat16)
+            else:
+                batch[key] = value.to(device="cuda")
+    return batch
+
+
+def _compute_probe_report(args: argparse.Namespace) -> dict:
+    _ensure_single_process_dist()
+    tokenizer, num_new_tokens, img_context_token_id = _configure_tokenizer(
+        args.model_name_or_path,
+        args.max_seq_length,
+    )
+    model = _configure_model(args, tokenizer, num_new_tokens, img_context_token_id)
+    batch = _build_batch(args, tokenizer, model)
+
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        outputs = model(**batch)
+    loss = outputs["loss"] if isinstance(outputs, dict) else outputs.loss
+    report = {
+        "model_name_or_path": args.model_name_or_path,
+        "meta_path": args.meta_path,
+        "dmole_arch_path": args.dmole_arch_path,
+        "autoencoder_path": args.autoencoder_path,
+        "input_ids_shape": list(batch["input_ids"].shape),
+        "labels_shape": list(batch["labels"].shape),
+        "pixel_values_shape": list(batch["pixel_values"].shape),
+        "image_flags_shape": list(batch["image_flags"].shape),
+        "supervised_tokens": int((batch["labels"] != -100).sum().item()),
+        "img_context_token_id": int(img_context_token_id),
+        "num_img_context_tokens": int(
+            (batch["input_ids"] == img_context_token_id).sum().item()
+        ),
+        "loss": None if loss is None else float(loss.detach().float().cpu()),
+        "loss_isfinite": None
+        if loss is None
+        else bool(torch.isfinite(loss.detach()).cpu()),
+        "loss_isnan": None
+        if loss is None
+        else bool(torch.isnan(loss.detach()).cpu()),
+    }
+
+    if loss is not None and torch.isfinite(loss.detach()):
+        model.zero_grad(set_to_none=True)
+        loss.backward()
+        grad_norms = []
+        for parameter in model.parameters():
+            if parameter.requires_grad and parameter.grad is not None:
+                grad_norms.append(parameter.grad.detach().float().norm())
+        if grad_norms:
+            total_grad_norm = torch.linalg.vector_norm(torch.stack(grad_norms))
+            report["grad_norm"] = float(total_grad_norm.cpu())
+            report["grad_norm_isfinite"] = bool(torch.isfinite(total_grad_norm).cpu())
+        else:
+            report["grad_norm"] = None
+            report["grad_norm_isfinite"] = False
+    else:
+        report["grad_norm"] = None
+        report["grad_norm_isfinite"] = False
+
+    return report
+
+
+def _write_report(report: dict, output_json: str) -> None:
+    output_path = Path(output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    parser = _build_argument_parser()
+    args = parser.parse_args()
+    report = _compute_probe_report(args)
+    _write_report(report, args.output_json)
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+    if report["supervised_tokens"] <= 0:
+        raise SystemExit("FATAL: no supervised tokens were found in the initial D-MoLE batch.")
+    if report["loss"] is None or not report["loss_isfinite"]:
+        raise SystemExit("FATAL: initial D-MoLE loss is non-finite.")
+    if report["loss"] <= 0.0:
+        raise SystemExit("FATAL: initial D-MoLE loss is not strictly positive.")
+    if not report["grad_norm_isfinite"]:
+        raise SystemExit("FATAL: initial D-MoLE gradient norm is non-finite.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/train/probe_initial_dmole_signal.py
+++ b/scripts/train/probe_initial_dmole_signal.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import json
+from contextlib import nullcontext
 from pathlib import Path
 
 import torch
@@ -49,7 +50,27 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--use-backbone-lora", type=int, default=8)
     parser.add_argument("--task-id", type=int, default=1)
     parser.add_argument("--max-seq-length", type=int, default=2048)
+    parser.add_argument(
+        "--torch-dtype",
+        default="bfloat16",
+        choices=("float32", "fp32", "bfloat16", "bf16"),
+    )
+    parser.add_argument(
+        "--attn-implementation",
+        default="flash_attention_2",
+    )
     return parser
+
+
+def _resolve_torch_dtype(dtype_name: str) -> tuple[str, torch.dtype]:
+    normalized = dtype_name.strip().lower()
+    dtype_map = {
+        "float32": torch.float32,
+        "fp32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+    }
+    return normalized, dtype_map[normalized]
 
 
 def _configure_tokenizer(model_path: str, max_seq_length: int):
@@ -82,11 +103,12 @@ def _configure_model(
     num_new_tokens: int,
     img_context_token_id: int,
 ):
+    normalized_dtype_name, torch_dtype = _resolve_torch_dtype(args.torch_dtype)
     config = InternVLChatConfig.from_pretrained(args.model_name_or_path)
     if config.llm_config.model_type == "internlm2":
-        config.llm_config.attn_implementation = "flash_attention_2"
+        config.llm_config.attn_implementation = args.attn_implementation
     else:
-        config.llm_config._attn_implementation = "flash_attention_2"
+        config.llm_config._attn_implementation = args.attn_implementation
     config.template = args.conv_style
     config.select_layer = -1
     config.dynamic_image_size = True
@@ -101,7 +123,7 @@ def _configure_model(
 
     model = InternVLChatModel.from_pretrained(
         args.model_name_or_path,
-        torch_dtype=torch.bfloat16,
+        torch_dtype=torch_dtype,
         config=config,
     )
     model.img_context_token_id = img_context_token_id
@@ -153,10 +175,10 @@ def _configure_model(
     model.vision_model.set_expert_masks(args.task_id)
     model.vision_model.freeze_old_experts(args.task_id)
     model.train()
-    return model.cuda()
+    return model.cuda(), normalized_dtype_name, torch_dtype
 
 
-def _build_batch(args: argparse.Namespace, tokenizer, model):
+def _build_batch(args: argparse.Namespace, tokenizer, model, batch_torch_dtype: torch.dtype):
     data_args = DataTrainingArguments(
         max_seq_length=args.max_seq_length,
         force_image_size=args.force_image_size,
@@ -187,7 +209,7 @@ def _build_batch(args: argparse.Namespace, tokenizer, model):
     for key, value in list(batch.items()):
         if isinstance(value, torch.Tensor):
             if key == "pixel_values":
-                batch[key] = value.to(device="cuda", dtype=torch.bfloat16)
+                batch[key] = value.to(device="cuda", dtype=batch_torch_dtype)
             else:
                 batch[key] = value.to(device="cuda")
     return batch
@@ -199,10 +221,17 @@ def _compute_probe_report(args: argparse.Namespace) -> dict:
         args.model_name_or_path,
         args.max_seq_length,
     )
-    model = _configure_model(args, tokenizer, num_new_tokens, img_context_token_id)
-    batch = _build_batch(args, tokenizer, model)
+    model, normalized_dtype_name, batch_torch_dtype = _configure_model(
+        args, tokenizer, num_new_tokens, img_context_token_id
+    )
+    batch = _build_batch(args, tokenizer, model, batch_torch_dtype)
 
-    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+    autocast_context = (
+        torch.autocast(device_type="cuda", dtype=batch_torch_dtype)
+        if batch_torch_dtype == torch.bfloat16
+        else nullcontext()
+    )
+    with autocast_context:
         outputs = model(**batch)
     loss = outputs["loss"] if isinstance(outputs, dict) else outputs.loss
     report = {
@@ -210,6 +239,8 @@ def _compute_probe_report(args: argparse.Namespace) -> dict:
         "meta_path": args.meta_path,
         "dmole_arch_path": args.dmole_arch_path,
         "autoencoder_path": args.autoencoder_path,
+        "torch_dtype": normalized_dtype_name,
+        "attn_implementation": args.attn_implementation,
         "input_ids_shape": list(batch["input_ids"].shape),
         "labels_shape": list(batch["labels"].shape),
         "pixel_values_shape": list(batch["pixel_values"].shape),

--- a/shell/dmole_internal/vizwiz_caption_minimal.json
+++ b/shell/dmole_internal/vizwiz_caption_minimal.json
@@ -1,0 +1,9 @@
+{
+    "vizwiz-caption": {
+        "root": ".",
+        "annotation": "data/vizwiz-caption/internal_minimal_train.jsonl",
+        "data_augment": false,
+        "repeat_time": 1,
+        "length": 256
+    }
+}

--- a/tests/test_score_policy.py
+++ b/tests/test_score_policy.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from internvl.scorer.score_policy import (
+    STRICT_SCORE_PROVENANCE,
+    load_score_frame,
+    select_enable_layers,
+)
+
+
+def _authoritative_score_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "layer": "language_model.layers.0.attn.qkv",
+                "score": 0.90,
+                "raw_score": 1.20,
+                "share_mean": 0.60,
+                "share_variance": 0.01,
+                "stability_penalty": 0.0277,
+                "modality": "language_model",
+                "modality_trust": 0.95,
+                "modality_frechet_variance": 0.02,
+                "sanitized_nonfinite": False,
+                "score_batches": 4,
+                "score_provenance": STRICT_SCORE_PROVENANCE,
+            },
+            {
+                "layer": "language_model.layers.1.attn.qkv",
+                "score": 0.70,
+                "raw_score": 1.05,
+                "share_mean": 0.40,
+                "share_variance": 0.01,
+                "stability_penalty": 0.0625,
+                "modality": "language_model",
+                "modality_trust": 0.95,
+                "modality_frechet_variance": 0.02,
+                "sanitized_nonfinite": False,
+                "score_batches": 4,
+                "score_provenance": STRICT_SCORE_PROVENANCE,
+            },
+            {
+                "layer": "vision_model.layers.0.attn.proj",
+                "score": 0.80,
+                "raw_score": 0.90,
+                "share_mean": 0.55,
+                "share_variance": 0.005,
+                "stability_penalty": 0.0165,
+                "modality": "vision_model",
+                "modality_trust": 0.90,
+                "modality_frechet_variance": 0.03,
+                "sanitized_nonfinite": False,
+                "score_batches": 4,
+                "score_provenance": STRICT_SCORE_PROVENANCE,
+            },
+            {
+                "layer": "vision_model.layers.1.attn.proj",
+                "score": 0.50,
+                "raw_score": 0.60,
+                "share_mean": 0.45,
+                "share_variance": 0.005,
+                "stability_penalty": 0.0246,
+                "modality": "vision_model",
+                "modality_trust": 0.90,
+                "modality_frechet_variance": 0.03,
+                "sanitized_nonfinite": False,
+                "score_batches": 4,
+                "score_provenance": STRICT_SCORE_PROVENANCE,
+            },
+        ]
+    )
+
+
+def test_load_score_frame_rejects_sanitized_authoritative_scores(tmp_path: Path) -> None:
+    frame = _authoritative_score_frame()
+    frame.loc[0, "sanitized_nonfinite"] = True
+    path = tmp_path / "score.csv"
+    frame.to_csv(path, index=False)
+
+    with pytest.raises(ValueError, match="sanitized_nonfinite"):
+        load_score_frame(path, require_authoritative=True)
+
+
+def test_select_enable_layers_prefers_deterministic_authoritative_order() -> None:
+    enable_layers = select_enable_layers(
+        _authoritative_score_frame(),
+        budget_portion=0.5,
+        require_authoritative=True,
+    )
+
+    assert enable_layers == [
+        "language_model.layers.0.attn.qkv",
+        "vision_model.layers.0.attn.proj",
+    ]
+
+
+def test_select_enable_layers_rejects_zero_authoritative_surface() -> None:
+    frame = _authoritative_score_frame()
+    frame["score"] = 0.0
+
+    with pytest.raises(ValueError, match="collapsed to zero"):
+        select_enable_layers(
+            frame,
+            budget_portion=0.5,
+            require_authoritative=True,
+        )
+
+
+def test_select_enable_layers_allows_deterministic_legacy_zero_fallback() -> None:
+    frame = pd.DataFrame(
+        [
+            {"layer": "language_model.layers.1.attn.qkv", "score": 0.0},
+            {"layer": "language_model.layers.0.attn.qkv", "score": 0.0},
+            {"layer": "vision_model.layers.1.attn.proj", "score": 0.0},
+            {"layer": "vision_model.layers.0.attn.proj", "score": 0.0},
+        ]
+    )
+
+    enable_layers = select_enable_layers(
+        frame,
+        budget_portion=0.5,
+        require_authoritative=False,
+    )
+
+    assert enable_layers == [
+        "language_model.layers.0.attn.qkv",
+        "vision_model.layers.0.attn.proj",
+    ]


### PR DESCRIPTION
## Summary
- rebuild InternLM supervision labels segment-by-segment so tokenization mismatches no longer wipe the training signal
- preserve the existing conversation packing flow while making the label surface deterministic for downstream D-MoLE scoring

## Validation
- python3 -m py_compile internvl/train/dataset.py
- pytest -q tests/test_score_policy.py
- verified the updated preprocessing path against the strict D-MoLE evidence lane during the review sweep